### PR TITLE
fix: commands directory references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Track and optimize your token usage across system prompts, user messages, tool o
    }
    ```
 
-3. **Create the `/tokenscope` command** by creating `~/.config/opencode/command/tokenscope.md`:
+3. **Create the `/tokenscope` command** by creating `~/.config/opencode/commands/tokenscope.md`:
 
 ```bash
-mkdir -p ~/.config/opencode/command
-cat > ~/.config/opencode/command/tokenscope.md << 'EOF'
+mkdir -p ~/.config/opencode/commands
+cat > ~/.config/opencode/commands/tokenscope.md << 'EOF'
 ---
 description: Analyze token usage across the current session with detailed breakdowns by category
 ---
@@ -402,7 +402,7 @@ Set any option to `false` to hide that section from the output.
 
 1. Verify `tokenscope.md` exists:
    ```bash
-   ls ~/.config/opencode/command/tokenscope.md
+   ls ~/.config/opencode/commands/tokenscope.md
    ```
 2. If missing, create it (see Installation step 3)
 3. Restart OpenCode completely

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -23,11 +23,11 @@ Track and optimize your token usage across system prompts, user messages, tool o
    }
    ```
 
-3. **Create the `/tokenscope` command** by creating `~/.config/opencode/command/tokenscope.md`:
+3. **Create the `/tokenscope` command** by creating `~/.config/opencode/commands/tokenscope.md`:
 
 ```bash
-mkdir -p ~/.config/opencode/command
-cat > ~/.config/opencode/command/tokenscope.md << 'EOF'
+mkdir -p ~/.config/opencode/commands
+cat > ~/.config/opencode/commands/tokenscope.md << 'EOF'
 ---
 description: Analyze token usage across the current session with detailed breakdowns by category
 ---
@@ -402,7 +402,7 @@ Set any option to `false` to hide that section from the output.
 
 1. Verify `tokenscope.md` exists:
    ```bash
-   ls ~/.config/opencode/command/tokenscope.md
+   ls ~/.config/opencode/commands/tokenscope.md
    ```
 2. If missing, create it (see Installation step 3)
 3. Restart OpenCode completely

--- a/plugin/install.sh
+++ b/plugin/install.sh
@@ -87,7 +87,7 @@ echo_info "All prerequisites met"
 echo_step "2/5 Preparing directories..."
 mkdir -p "$OPENCODE_DIR/plugin"
 mkdir -p "$OPENCODE_DIR/plugin/tokenscope-lib"
-mkdir -p "$OPENCODE_DIR/command"
+mkdir -p "$OPENCODE_DIR/commands"
 echo_info "Directories ready"
 
 # Download files
@@ -108,7 +108,7 @@ FILES=(
     "plugin/package.json"
     "plugin/tokenscope-config.json"
     "plugin/install.sh"
-    "command/tokenscope.md"
+    "commands/tokenscope.md"
 )
 
 for file in "${FILES[@]}"; do
@@ -124,7 +124,7 @@ for file in "${FILES[@]}"; do
         elif [ "$dir" = "plugin/tokenscope-lib" ]; then
             mv "$TEMP_DIR/$filename" "$OPENCODE_DIR/plugin/tokenscope-lib/$filename"
         else
-            mv "$TEMP_DIR/$filename" "$OPENCODE_DIR/command/$filename"
+            mv "$TEMP_DIR/$filename" "$OPENCODE_DIR/commands/$filename"
         fi
     else
         echo_error "Failed to download $file"
@@ -174,7 +174,7 @@ REQUIRED_FILES=(
     "$OPENCODE_DIR/plugin/tokenscope-config.json"
     "$OPENCODE_DIR/plugin/node_modules/js-tiktoken"
     "$OPENCODE_DIR/plugin/node_modules/@huggingface/transformers"
-    "$OPENCODE_DIR/command/tokenscope.md"
+    "$OPENCODE_DIR/commands/tokenscope.md"
 )
 
 all_present=true
@@ -209,7 +209,7 @@ echo "╚═══════════════════════�
 echo ""
 echo_info "Version: $INSTALLED_VERSION"
 echo_info "Plugin installed at: $OPENCODE_DIR/plugin/tokenscope.ts"
-echo_info "Command installed at: $OPENCODE_DIR/command/tokenscope.md"
+echo_info "Command installed at: $OPENCODE_DIR/commands/tokenscope.md"
 echo ""
 echo_step "Next steps:"
 echo "  1. Restart OpenCode"


### PR DESCRIPTION
## Purpose
Ensure docs and installer reference the correct `commands/` directory so custom commands load properly.

## Changes
- Update `README.md` and `plugin/README.md` paths to use `~/.config/opencode/commands`.
- Update `plugin/install.sh` to install and verify `commands/tokenscope.md`.

## Reference
https://opencode.ai/docs/commands/ — "Create markdown files in the `commands/` directory to define custom commands."