### PR TITLE
feat(pricing): sync models from models.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ cat token-usage-output.txt
 - **Effective Rate**: Shows what you're actually paying per token vs standard rates
 
 ### Accurate Cost Tracking
-- **41+ Models Supported**: Comprehensive pricing database for Claude, GPT, DeepSeek, Llama, Mistral, and more
+- **Models.dev Pricing Database**: Pricing data synced from models.dev across thousands of provider/model entries
 - **Cache-Aware Pricing**: Properly handles cache read/write tokens with discounted rates
 - **Session-Wide Billing**: Aggregates costs across all API calls in your session
 
@@ -359,7 +359,7 @@ SUMMARY
 
 ## Supported Models
 
-**41+ models with accurate pricing:**
+**Pricing data is synced from models.dev across thousands of provider/model entries:**
 
 ### Claude Models
 - Claude Opus 4.5, 4.1, 4

--- a/README.md
+++ b/README.md
@@ -382,7 +382,21 @@ SUMMARY
 
 ## Configuration
 
-The plugin includes a `tokenscope-config.json` file with these defaults:
+TokenScope now supports a stable user override file at:
+
+```bash
+~/.config/opencode/tokenscope-config.json
+```
+
+On startup, the plugin loads config in this order:
+1. `~/.config/opencode/tokenscope-config.json`
+2. bundled package config: `tokenscope-config.json`
+3. in-code defaults
+
+Any missing keys are filled from the built-in defaults, so you can override only the flags you care about.
+This is safer than editing the file inside the global npm package directory, because `npm update -g` can replace that installed package and overwrite local changes.
+
+Default flags:
 
 ```json
 {
@@ -391,6 +405,15 @@ The plugin includes a `tokenscope-config.json` file with these defaults:
   "enableCacheEfficiency": true,
   "enableSubagentAnalysis": true,
   "enableSkillAnalysis": true
+}
+```
+
+Example user override:
+
+```json
+{
+  "enableSubagentAnalysis": false,
+  "enableSkillAnalysis": false
 }
 ```
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -383,7 +383,21 @@ SUMMARY
 
 ## Configuration
 
-The plugin includes a `tokenscope-config.json` file with these defaults:
+TokenScope now supports a stable user override file at:
+
+```bash
+~/.config/opencode/tokenscope-config.json
+```
+
+On startup, the plugin loads config in this order:
+1. `~/.config/opencode/tokenscope-config.json`
+2. bundled package config: `tokenscope-config.json`
+3. in-code defaults
+
+Any missing keys are filled from the built-in defaults, so you can override only the flags you care about.
+This is safer than editing the file inside the global npm package directory, because `npm update -g` can replace that installed package and overwrite local changes.
+
+Default flags:
 
 ```json
 {
@@ -392,6 +406,15 @@ The plugin includes a `tokenscope-config.json` file with these defaults:
   "enableCacheEfficiency": true,
   "enableSubagentAnalysis": true,
   "enableSkillAnalysis": true
+}
+```
+
+Example user override:
+
+```json
+{
+  "enableSubagentAnalysis": false,
+  "enableSkillAnalysis": false
 }
 ```
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -134,7 +134,7 @@ cat token-usage-output.txt
 - **Effective Rate**: Shows what you're actually paying per token vs standard rates
 
 ### Accurate Cost Tracking
-- **41+ Models Supported**: Comprehensive pricing database for Claude, GPT, DeepSeek, Llama, Mistral, and more
+- **Models.dev Pricing Database**: Pricing data synced from models.dev across thousands of provider/model entries
 - **Cache-Aware Pricing**: Properly handles cache read/write tokens with discounted rates
 - **Session-Wide Billing**: Aggregates costs across all API calls in your session
 
@@ -360,7 +360,7 @@ SUMMARY
 
 ## Supported Models
 
-**41+ models with accurate pricing:**
+**Pricing data is synced from models.dev across thousands of provider/model entries:**
 
 ### Claude Models
 - Claude Opus 4.5, 4.1, 4

--- a/plugin/models.json
+++ b/plugin/models.json
@@ -1,103 +1,4801 @@
 {
-  "allenai/molmo-2-8b:free": {
+  "302ai/chatgpt-4o-latest": {
+    "input": 5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/claude-haiku-4-5-20251001": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/claude-opus-4-1-20250805": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/claude-opus-4-1-20250805-thinking": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/claude-opus-4-5-20251101": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/claude-opus-4-5-20251101-thinking": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/claude-sonnet-4-5-20250929": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/claude-sonnet-4-5-20250929-thinking": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/deepseek-chat": {
+    "input": 0.29,
+    "output": 0.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/deepseek-reasoner": {
+    "input": 0.29,
+    "output": 0.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/deepseek-v3.2": {
+    "input": 0.29,
+    "output": 0.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/deepseek-v3.2-thinking": {
+    "input": 0.29,
+    "output": 0.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/doubao-seed-1-6-thinking-250715": {
+    "input": 0.121,
+    "output": 1.21,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/doubao-seed-1-6-vision-250815": {
+    "input": 0.114,
+    "output": 1.143,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/doubao-seed-1-8-251215": {
+    "input": 0.114,
+    "output": 0.286,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/doubao-seed-code-preview-251028": {
+    "input": 0.17,
+    "output": 1.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gemini-2.0-flash-lite": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gemini-2.5-flash-image": {
+    "input": 0.3,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gemini-2.5-flash-lite-preview-09-2025": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gemini-2.5-flash-nothink": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gemini-2.5-flash-preview-09-2025": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gemini-3-pro-image-preview": {
+    "input": 2,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gemini-3-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/glm-4.5": {
+    "input": 0.286,
+    "output": 1.142,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/glm-4.5v": {
+    "input": 0.29,
+    "output": 0.86,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/glm-4.6": {
+    "input": 0.286,
+    "output": 1.142,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/glm-4.6v": {
+    "input": 0.145,
+    "output": 0.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/glm-4.7": {
+    "input": 0.286,
+    "output": 1.142,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-4o": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-5-pro": {
+    "input": 15,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-5-thinking": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-5.1-chat-latest": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/gpt-5.2-chat-latest": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/grok-4-1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/grok-4-1-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/grok-4-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/grok-4-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/grok-4.1": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/kimi-k2-0905-preview": {
+    "input": 0.632,
+    "output": 2.53,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/kimi-k2-thinking": {
+    "input": 0.575,
+    "output": 2.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/kimi-k2-thinking-turbo": {
+    "input": 1.265,
+    "output": 9.119,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/minimax-m1": {
+    "input": 0.132,
+    "output": 1.254,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/minimax-m2": {
+    "input": 0.33,
+    "output": 1.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/ministral-14b-2512": {
+    "input": 0.33,
+    "output": 0.33,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/mistral-large-2512": {
+    "input": 1.1,
+    "output": 3.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/qwen-flash": {
+    "input": 0.022,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/qwen-max-latest": {
+    "input": 0.343,
+    "output": 1.372,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/qwen-plus": {
+    "input": 0.12,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/qwen3-235b-a22b": {
+    "input": 0.29,
+    "output": 2.86,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.29,
+    "output": 1.143,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/qwen3-30b-a3b": {
+    "input": 0.11,
+    "output": 1.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.86,
+    "output": 3.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "302ai/qwen3-max-2025-09-23": {
+    "input": 0.86,
+    "output": 3.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/claude-3-7-sonnet-20250219": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/claude-haiku-4-5-20251001": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/claude-opus-4-1-20250805": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/claude-opus-4-20250514": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/claude-opus-4-5-20251101": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/claude-sonnet-4-20250514": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/claude-sonnet-4-5-20250929": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/deepseek-ai/deepseek-r1": {
+    "input": 3,
+    "output": 7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/deepseek-ai/deepseek-v3.1-terminus": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/deepseek-ai/deepseek-v3.2": {
+    "input": 0.27,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/deepseek/deepseek-v3.1": {
+    "input": 0.55,
+    "output": 1.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gemini-3.1-flash-lite-preview": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 1,
+    "cacheRead": 0.025
+  },
+  "abacus/gemini-3.1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-4o-2024-11-20": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-4o-mini": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5.1-chat-latest": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5.1-codex-max": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5.2-chat-latest": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5.3-chat-latest": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5.3-codex-xhigh": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/grok-4-0709": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/grok-4-1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/grok-4-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/kimi-k2-turbo-preview": {
+    "input": 0.15,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/llama-3.3-70b-versatile": {
+    "input": 0.59,
+    "output": 0.79,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+    "input": 0.14,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/meta-llama/meta-llama-3.1-405b-instruct-turbo": {
+    "input": 3.5,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/meta-llama/meta-llama-3.1-8b-instruct": {
+    "input": 0.02,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/o3": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/o3-pro": {
+    "input": 20,
+    "output": 40,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/openai/gpt-oss-120b": {
+    "input": 0.08,
+    "output": 0.44,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/qwen-2.5-coder-32b": {
+    "input": 0.79,
+    "output": 0.79,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/qwen/qwen2.5-72b-instruct": {
+    "input": 0.11,
+    "output": 0.38,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/qwen/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.13,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/qwen/qwen3-32b": {
+    "input": 0.09,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.29,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/qwen/qwq-32b": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/qwen3-max": {
+    "input": 1.2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/route-llm": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/zai-org/glm-4.5": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/zai-org/glm-4.6": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/zai-org/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "abacus/zai-org/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ai21-jamba-1.5-large": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "anthropic/claude-3.5-haiku": {
+  "ai21-jamba-1.5-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/claude-haiku-4-5": {
+    "input": 1.1,
+    "output": 5.5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.11
+  },
+  "aihubmix/claude-opus-4-1": {
+    "input": 16.5,
+    "output": 82.5,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "aihubmix/claude-opus-4-5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "aihubmix/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "aihubmix/claude-opus-4-6-think": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "aihubmix/claude-sonnet-4-5": {
+    "input": 3.3,
+    "output": 16.5,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "aihubmix/claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "aihubmix/claude-sonnet-4-6-think": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "aihubmix/coding-glm-4.7": {
+    "input": 0.27,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0.548
+  },
+  "aihubmix/coding-glm-4.7-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/coding-glm-5-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/coding-minimax-m2.1-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/deepseek-v3.2": {
+    "input": 0.3,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/deepseek-v3.2-fast": {
+    "input": 1.1,
+    "output": 3.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/deepseek-v3.2-think": {
+    "input": 0.3,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/gemini-2.5-flash": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "aihubmix/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0.31
+  },
+  "aihubmix/gemini-3-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "aihubmix/gemini-3-pro-preview-search": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "aihubmix/glm-4.6v": {
+    "input": 0.14,
+    "output": 0.41,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/glm-4.7": {
+    "input": 0.27,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0.548
+  },
+  "aihubmix/glm-5": {
+    "input": 0.88,
+    "output": 2.82,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "aihubmix/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "aihubmix/gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "aihubmix/gpt-4o": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "aihubmix/gpt-5": {
+    "input": 5,
+    "output": 20,
+    "cacheWrite": 0,
+    "cacheRead": 2.5
+  },
+  "aihubmix/gpt-5-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "aihubmix/gpt-5-mini": {
+    "input": 1.5,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "aihubmix/gpt-5-nano": {
+    "input": 0.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "aihubmix/gpt-5-pro": {
+    "input": 7,
+    "output": 28,
+    "cacheWrite": 0,
+    "cacheRead": 3.5
+  },
+  "aihubmix/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "aihubmix/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "aihubmix/gpt-5.1-codex-max": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "aihubmix/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "aihubmix/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "aihubmix/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "aihubmix/kimi-k2-0905": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "aihubmix/minimax-m2.1": {
+    "input": 0.29,
+    "output": 1.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/minimax-m2.5": {
+    "input": 0.29,
+    "output": 1.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/o4-mini": {
+    "input": 1.5,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "aihubmix/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.28,
+    "output": 1.12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.28,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.82,
+    "output": 3.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/qwen3-coder-next": {
+    "input": 0.14,
+    "output": 0.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/qwen3-max-2026-01-23": {
+    "input": 0.34,
+    "output": 1.37,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aihubmix/qwen3.5-plus": {
+    "input": 0.11,
+    "output": 0.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aion-2.0": {
+    "input": 0.8,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aion-labs.aion-2-0": {
+    "input": 1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "alibaba-cn/deepseek-r1": {
+    "input": 0.574,
+    "output": 2.294,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/deepseek-r1-0528": {
+    "input": 0.574,
+    "output": 2.294,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/deepseek-r1-distill-llama-70b": {
+    "input": 0.287,
+    "output": 0.861,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/deepseek-r1-distill-llama-8b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/deepseek-r1-distill-qwen-1-5b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/deepseek-r1-distill-qwen-14b": {
+    "input": 0.144,
+    "output": 0.431,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/deepseek-r1-distill-qwen-32b": {
+    "input": 0.287,
+    "output": 0.861,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/deepseek-r1-distill-qwen-7b": {
+    "input": 0.072,
+    "output": 0.144,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/deepseek-v3": {
+    "input": 0.287,
+    "output": 1.147,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/deepseek-v3-1": {
+    "input": 0.574,
+    "output": 1.721,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/deepseek-v3-2-exp": {
+    "input": 0.287,
+    "output": 0.431,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/glm-5": {
+    "input": 0.86,
+    "output": 3.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/kimi-k2-thinking": {
+    "input": 0.574,
+    "output": 2.294,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/kimi-k2.5": {
+    "input": 0.574,
+    "output": 2.411,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/kimi/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "alibaba-cn/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/minimax/minimax-m2.7": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "alibaba-cn/moonshot-kimi-k2-instruct": {
+    "input": 0.574,
+    "output": 2.294,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qvq-max": {
+    "input": 1.147,
+    "output": 4.588,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-deep-research": {
+    "input": 7.742,
+    "output": 23.367,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-doc-turbo": {
+    "input": 0.087,
+    "output": 0.144,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-flash": {
+    "input": 0.022,
+    "output": 0.216,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-long": {
+    "input": 0.072,
+    "output": 0.287,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-math-plus": {
+    "input": 0.574,
+    "output": 1.721,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-math-turbo": {
+    "input": 0.287,
+    "output": 0.861,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-max": {
+    "input": 0.345,
+    "output": 1.377,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-mt-plus": {
+    "input": 0.259,
+    "output": 0.775,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-mt-turbo": {
+    "input": 0.101,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-omni-turbo": {
+    "input": 0.058,
+    "output": 0.23,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-omni-turbo-realtime": {
+    "input": 0.23,
+    "output": 0.918,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-plus": {
+    "input": 0.115,
+    "output": 0.287,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-plus-character": {
+    "input": 0.115,
+    "output": 0.287,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-turbo": {
+    "input": 0.044,
+    "output": 0.087,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-vl-max": {
+    "input": 0.23,
+    "output": 0.574,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-vl-ocr": {
+    "input": 0.717,
+    "output": 0.717,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen-vl-plus": {
+    "input": 0.115,
+    "output": 0.287,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen2-5-14b-instruct": {
+    "input": 0.144,
+    "output": 0.431,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen2-5-32b-instruct": {
+    "input": 0.287,
+    "output": 0.861,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen2-5-72b-instruct": {
+    "input": 0.574,
+    "output": 1.721,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen2-5-7b-instruct": {
+    "input": 0.072,
+    "output": 0.144,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen2-5-coder-32b-instruct": {
+    "input": 0.287,
+    "output": 0.861,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen2-5-coder-7b-instruct": {
+    "input": 0.144,
+    "output": 0.287,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen2-5-math-72b-instruct": {
+    "input": 0.574,
+    "output": 1.721,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen2-5-math-7b-instruct": {
+    "input": 0.144,
+    "output": 0.287,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen2-5-omni-7b": {
+    "input": 0.087,
+    "output": 0.345,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen2-5-vl-72b-instruct": {
+    "input": 2.294,
+    "output": 6.881,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen2-5-vl-7b-instruct": {
+    "input": 0.287,
+    "output": 0.717,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-14b": {
+    "input": 0.144,
+    "output": 0.574,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-235b-a22b": {
+    "input": 0.287,
+    "output": 1.147,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-32b": {
+    "input": 0.287,
+    "output": 1.147,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-8b": {
+    "input": 0.072,
+    "output": 0.287,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-asr-flash": {
+    "input": 0.032,
+    "output": 0.032,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.216,
+    "output": 0.861,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.861,
+    "output": 3.441,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-coder-flash": {
+    "input": 0.144,
+    "output": 0.574,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-coder-plus": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-max": {
+    "input": 0.861,
+    "output": 3.441,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-next-80b-a3b-instruct": {
+    "input": 0.144,
+    "output": 0.574,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-next-80b-a3b-thinking": {
+    "input": 0.144,
+    "output": 1.434,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-omni-flash": {
+    "input": 0.058,
+    "output": 0.23,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-omni-flash-realtime": {
+    "input": 0.23,
+    "output": 0.918,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-vl-235b-a22b": {
+    "input": 0.286705,
+    "output": 1.14682,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-vl-30b-a3b": {
+    "input": 0.108,
+    "output": 0.431,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3-vl-plus": {
+    "input": 0.143353,
+    "output": 1.433525,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3.5-397b-a17b": {
+    "input": 0.43,
+    "output": 2.58,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3.5-flash": {
+    "input": 0.172,
+    "output": 1.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3.5-plus": {
+    "input": 0.573,
+    "output": 3.44,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwen3.6-plus": {
+    "input": 1.146,
+    "output": 6.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwq-32b": {
+    "input": 0.287,
+    "output": 0.861,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/qwq-plus": {
+    "input": 0.23,
+    "output": 0.574,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/siliconflow/deepseek-r1-0528": {
+    "input": 0.5,
+    "output": 2.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/siliconflow/deepseek-v3-0324": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/siliconflow/deepseek-v3.1-terminus": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/siliconflow/deepseek-v3.2": {
+    "input": 0.27,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-cn/tongyi-intent-detect-v3": {
+    "input": 0.058,
+    "output": 0.144,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan-cn/glm-4.7": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan-cn/glm-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan-cn/kimi-k2.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan-cn/minimax-m2.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan-cn/qwen3-coder-next": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan-cn/qwen3-coder-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan-cn/qwen3-max-2026-01-23": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan-cn/qwen3.5-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan/glm-4.7": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan/glm-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan/kimi-k2.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan/minimax-m2.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan/qwen3-coder-next": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan/qwen3-coder-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan/qwen3-max-2026-01-23": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba-coding-plan/qwen3.5-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qvq-max": {
+    "input": 1.2,
+    "output": 4.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-flash": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-max": {
+    "input": 1.6,
+    "output": 6.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-mt-plus": {
+    "input": 2.46,
+    "output": 7.37,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-mt-turbo": {
+    "input": 0.16,
+    "output": 0.49,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-omni-turbo": {
+    "input": 0.07,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-omni-turbo-realtime": {
+    "input": 0.27,
+    "output": 1.07,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-plus": {
+    "input": 0.4,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-plus-character-ja": {
+    "input": 0.5,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-turbo": {
+    "input": 0.05,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-vl-max": {
+    "input": 0.8,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-vl-ocr": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen-vl-plus": {
+    "input": 0.21,
+    "output": 0.63,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen2-5-14b-instruct": {
+    "input": 0.35,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen2-5-32b-instruct": {
+    "input": 0.7,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen2-5-72b-instruct": {
+    "input": 1.4,
+    "output": 5.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen2-5-7b-instruct": {
+    "input": 0.175,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen2-5-omni-7b": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen2-5-vl-72b-instruct": {
+    "input": 2.8,
+    "output": 8.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen2-5-vl-7b-instruct": {
+    "input": 0.35,
+    "output": 1.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-14b": {
+    "input": 0.35,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-235b-a22b": {
+    "input": 0.7,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-32b": {
+    "input": 0.7,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-8b": {
+    "input": 0.18,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-asr-flash": {
+    "input": 0.035,
+    "output": 0.035,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.45,
+    "output": 2.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-coder-480b-a35b-instruct": {
+    "input": 1.5,
+    "output": 7.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-coder-flash": {
+    "input": 0.3,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-coder-plus": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-livetranslate-flash-realtime": {
+    "input": 10,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-max": {
+    "input": 1.2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-next-80b-a3b-instruct": {
+    "input": 0.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-next-80b-a3b-thinking": {
+    "input": 0.5,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-omni-flash": {
+    "input": 0.43,
+    "output": 1.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-omni-flash-realtime": {
+    "input": 0.52,
+    "output": 1.99,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-vl-235b-a22b": {
+    "input": 0.7,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-vl-30b-a3b": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3-vl-plus": {
+    "input": 0.2,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3.5-397b-a17b": {
+    "input": 0.6,
+    "output": 3.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwen3.5-plus": {
+    "input": 0.4,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "alibaba/qwq-plus": {
+    "input": 0.8,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "allam-2-7b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/amazon.nova-2-lite-v1:0": {
+    "input": 0.33,
+    "output": 2.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/amazon.nova-lite-v1:0": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0.015
+  },
+  "amazon-bedrock/amazon.nova-micro-v1:0": {
+    "input": 0.035,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0.00875
+  },
+  "amazon-bedrock/amazon.nova-premier-v1:0": {
+    "input": 2.5,
+    "output": 12.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/amazon.nova-pro-v1:0": {
+    "input": 0.8,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "amazon-bedrock/anthropic.claude-3-5-haiku-20241022-v1:0": {
     "input": 0.8,
     "output": 4,
     "cacheWrite": 1,
     "cacheRead": 0.08
   },
-  "anthropic/claude-3.7-sonnet": {
-    "input": 15,
-    "output": 75,
-    "cacheWrite": 18.75,
-    "cacheRead": 1.5
+  "amazon-bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
   },
-  "anthropic/claude-haiku-4.5": {
+  "amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/anthropic.claude-3-haiku-20240307-v1:0": {
+    "input": 0.25,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/anthropic.claude-haiku-4-5-20251001-v1:0": {
     "input": 1,
     "output": 5,
     "cacheWrite": 1.25,
     "cacheRead": 0.1
   },
-  "anthropic/claude-opus-4": {
+  "amazon-bedrock/anthropic.claude-opus-4-1-20250805-v1:0": {
     "input": 15,
     "output": 75,
     "cacheWrite": 18.75,
     "cacheRead": 1.5
   },
-  "anthropic/claude-opus-4.1": {
+  "amazon-bedrock/anthropic.claude-opus-4-20250514-v1:0": {
     "input": 15,
     "output": 75,
     "cacheWrite": 18.75,
     "cacheRead": 1.5
   },
-  "anthropic/claude-opus-4.5": {
+  "amazon-bedrock/anthropic.claude-opus-4-5-20251101-v1:0": {
     "input": 5,
     "output": 25,
     "cacheWrite": 6.25,
     "cacheRead": 0.5
   },
-  "anthropic/claude-opus-4.6": {
+  "amazon-bedrock/anthropic.claude-opus-4-6-v1": {
     "input": 5,
     "output": 25,
     "cacheWrite": 6.25,
     "cacheRead": 0.5
   },
-  "anthropic/claude-sonnet-4": {
+  "amazon-bedrock/anthropic.claude-sonnet-4-20250514-v1:0": {
     "input": 3,
     "output": 15,
     "cacheWrite": 3.75,
     "cacheRead": 0.3
   },
-  "anthropic/claude-sonnet-4.5": {
+  "amazon-bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "input": 3,
     "output": 15,
     "cacheWrite": 3.75,
     "cacheRead": 0.3
   },
-  "arcee-ai/trinity-large-preview:free": {
+  "amazon-bedrock/anthropic.claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/deepseek.r1-v1:0": {
+    "input": 1.35,
+    "output": 5.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/deepseek.v3-v1:0": {
+    "input": 0.58,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/deepseek.v3.2": {
+    "input": 0.62,
+    "output": 1.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "amazon-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "amazon-bedrock/eu.anthropic.claude-opus-4-6-v1": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "amazon-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/eu.anthropic.claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "amazon-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "amazon-bedrock/global.anthropic.claude-opus-4-6-v1": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "amazon-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/global.anthropic.claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/google.gemma-3-12b-it": {
+    "input": 0.05,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/google.gemma-3-27b-it": {
+    "input": 0.12,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/google.gemma-3-4b-it": {
+    "input": 0.04,
+    "output": 0.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/meta.llama3-1-405b-instruct-v1:0": {
+    "input": 2.4,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/meta.llama3-1-70b-instruct-v1:0": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/meta.llama3-1-8b-instruct-v1:0": {
+    "input": 0.22,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/meta.llama3-2-11b-instruct-v1:0": {
+    "input": 0.16,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/meta.llama3-2-1b-instruct-v1:0": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/meta.llama3-2-3b-instruct-v1:0": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/meta.llama3-2-90b-instruct-v1:0": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/meta.llama3-3-70b-instruct-v1:0": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/meta.llama4-maverick-17b-instruct-v1:0": {
+    "input": 0.24,
+    "output": 0.97,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/meta.llama4-scout-17b-instruct-v1:0": {
+    "input": 0.17,
+    "output": 0.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/minimax.minimax-m2": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/minimax.minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/minimax.minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/mistral.devstral-2-123b": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/mistral.magistral-small-2509": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/mistral.ministral-3-14b-instruct": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/mistral.ministral-3-3b-instruct": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/mistral.ministral-3-8b-instruct": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/mistral.mistral-large-3-675b-instruct": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/mistral.pixtral-large-2502-v1:0": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/mistral.voxtral-mini-3b-2507": {
+    "input": 0.04,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/mistral.voxtral-small-24b-2507": {
+    "input": 0.15,
+    "output": 0.35,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/moonshot.kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/moonshotai.kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/nvidia.nemotron-nano-12b-v2": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/nvidia.nemotron-nano-3-30b": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/nvidia.nemotron-nano-9b-v2": {
+    "input": 0.06,
+    "output": 0.23,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/nvidia.nemotron-super-3-120b": {
+    "input": 0.15,
+    "output": 0.65,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/openai.gpt-oss-120b-1:0": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/openai.gpt-oss-20b-1:0": {
+    "input": 0.07,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/openai.gpt-oss-safeguard-120b": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/openai.gpt-oss-safeguard-20b": {
+    "input": 0.07,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/qwen.qwen3-235b-a22b-2507-v1:0": {
+    "input": 0.22,
+    "output": 0.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/qwen.qwen3-32b-v1:0": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/qwen.qwen3-coder-30b-a3b-v1:0": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/qwen.qwen3-coder-480b-a35b-v1:0": {
+    "input": 0.22,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/qwen.qwen3-next-80b-a3b": {
+    "input": 0.14,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/qwen.qwen3-vl-235b-a22b": {
+    "input": 0.3,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "amazon-bedrock/us.anthropic.claude-opus-4-1-20250805-v1:0": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "amazon-bedrock/us.anthropic.claude-opus-4-20250514-v1:0": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "amazon-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "amazon-bedrock/us.anthropic.claude-opus-4-6-v1": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "amazon-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/us.anthropic.claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "amazon-bedrock/writer.palmyra-x4-v1:0": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/writer.palmyra-x5-v1:0": {
+    "input": 0.6,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/zai.glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/zai.glm-4.7-flash": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon-bedrock/zai.glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon.nova-2-lite-v1:0": {
+    "input": 0.33,
+    "output": 2.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon.nova-lite-v1:0": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0.015
+  },
+  "amazon.nova-micro-v1:0": {
+    "input": 0.035,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0.00875
+  },
+  "amazon.nova-premier-v1:0": {
+    "input": 2.5,
+    "output": 12.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "amazon.nova-pro-v1:0": {
+    "input": 0.8,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "amoral-gemma3-27b-v2": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "anthropic--claude-3-haiku": {
+    "input": 0.25,
+    "output": 1.25,
+    "cacheWrite": 0.3,
+    "cacheRead": 0.03
+  },
+  "anthropic--claude-3-opus": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "anthropic--claude-3-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic--claude-3.5-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic--claude-3.7-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic--claude-4-opus": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "anthropic--claude-4-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic--claude-4.5-haiku": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "anthropic--claude-4.5-opus": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "anthropic--claude-4.5-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic--claude-4.6-opus": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "anthropic--claude-4.6-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic.claude-3-5-haiku-20241022-v1:0": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "anthropic.claude-3-5-sonnet-20240620-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic.claude-3-5-sonnet-20241022-v2:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic.claude-3-7-sonnet-20250219-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic.claude-3-haiku-20240307-v1:0": {
+    "input": 0.25,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "anthropic.claude-opus-4-1-20250805-v1:0": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "anthropic.claude-opus-4-20250514-v1:0": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "anthropic.claude-opus-4-5-20251101-v1:0": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "anthropic.claude-opus-4-6-v1": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "anthropic.claude-sonnet-4-20250514-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic.claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic/claude-3-5-haiku-20241022": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "anthropic/claude-3-5-haiku-latest": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "anthropic/claude-3-5-sonnet-20240620": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic/claude-3-5-sonnet-20241022": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic/claude-3-7-sonnet-20250219": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic/claude-3-haiku-20240307": {
+    "input": 0.25,
+    "output": 1.25,
+    "cacheWrite": 0.3,
+    "cacheRead": 0.03
+  },
+  "anthropic/claude-3-opus-20240229": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "anthropic/claude-3-sonnet-20240229": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0.3,
+    "cacheRead": 0.3
+  },
+  "anthropic/claude-haiku-4-5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "anthropic/claude-haiku-4-5-20251001": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "anthropic/claude-opus-4-0": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "anthropic/claude-opus-4-1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "anthropic/claude-opus-4-1-20250805": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "anthropic/claude-opus-4-20250514": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "anthropic/claude-opus-4-5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "anthropic/claude-opus-4-5-20251101": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "anthropic/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "anthropic/claude-sonnet-4-0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic/claude-sonnet-4-20250514": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic/claude-sonnet-4-5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic/claude-sonnet-4-5-20250929": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anthropic/claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "anubis-70b-v1": {
+    "input": 0.31,
+    "output": 0.31,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "anubis-70b-v1.1": {
+    "input": 0.31,
+    "output": 0.31,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "asi1-mini": {
+    "input": 1,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "aura-2-en": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "arcee-ai/trinity-mini:free": {
+  "aura-2-es": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "black-forest-labs/flux.2-flex": {
+  "auto-free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "black-forest-labs/flux.2-klein-4b": {
+  "auto-model": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "black-forest-labs/flux.2-max": {
+  "auto-model-basic": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "auto-model-premium": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "auto-model-standard": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "auto-small": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "autoglm-phone-9b-multilingual": {
+    "input": 0.035,
+    "output": 0.138,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/claude-haiku-4-5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "azure-cognitive-services/claude-opus-4-1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "azure-cognitive-services/claude-opus-4-5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "azure-cognitive-services/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "azure-cognitive-services/claude-sonnet-4-5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "azure-cognitive-services/codestral-2501": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/codex-mini": {
+    "input": 1.5,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.375
+  },
+  "azure-cognitive-services/cohere-command-a": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/cohere-command-r-08-2024": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/cohere-command-r-plus-08-2024": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/cohere-embed-v-4-0": {
+    "input": 0.12,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/cohere-embed-v3-english": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/cohere-embed-v3-multilingual": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/deepseek-r1": {
+    "input": 1.35,
+    "output": 5.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/deepseek-r1-0528": {
+    "input": 1.35,
+    "output": 5.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/deepseek-v3-0324": {
+    "input": 1.14,
+    "output": 4.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/deepseek-v3.1": {
+    "input": 0.56,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/deepseek-v3.2": {
+    "input": 0.58,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/deepseek-v3.2-speciale": {
+    "input": 0.58,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/gpt-3.5-turbo-0125": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/gpt-3.5-turbo-0301": {
+    "input": 1.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/gpt-3.5-turbo-0613": {
+    "input": 3,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/gpt-3.5-turbo-1106": {
+    "input": 1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/gpt-3.5-turbo-instruct": {
+    "input": 1.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/gpt-4": {
+    "input": 60,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/gpt-4-32k": {
+    "input": 60,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/gpt-4-turbo": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/gpt-4-turbo-vision": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "azure-cognitive-services/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "azure-cognitive-services/gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "azure-cognitive-services/gpt-4o": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "azure-cognitive-services/gpt-4o-mini": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "azure-cognitive-services/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "azure-cognitive-services/gpt-5-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "azure-cognitive-services/gpt-5-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "azure-cognitive-services/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "azure-cognitive-services/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "azure-cognitive-services/gpt-5-pro": {
+    "input": 15,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "azure-cognitive-services/gpt-5.1-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "azure-cognitive-services/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "azure-cognitive-services/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "azure-cognitive-services/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "azure-cognitive-services/gpt-5.2-chat": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "azure-cognitive-services/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "azure-cognitive-services/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "azure-cognitive-services/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "azure-cognitive-services/gpt-5.4-mini": {
+    "input": 0.75,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "azure-cognitive-services/gpt-5.4-nano": {
+    "input": 0.2,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "azure-cognitive-services/gpt-5.4-pro": {
+    "input": 30,
+    "output": 180,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/grok-3": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "azure-cognitive-services/grok-3-mini": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "azure-cognitive-services/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "azure-cognitive-services/grok-4-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "azure-cognitive-services/grok-4-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "azure-cognitive-services/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "azure-cognitive-services/kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "azure-cognitive-services/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/llama-3.2-11b-vision-instruct": {
+    "input": 0.37,
+    "output": 0.37,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/llama-3.2-90b-vision-instruct": {
+    "input": 2.04,
+    "output": 2.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/llama-3.3-70b-instruct": {
+    "input": 0.71,
+    "output": 0.71,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/llama-4-maverick-17b-128e-instruct-fp8": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/llama-4-scout-17b-16e-instruct": {
+    "input": 0.2,
+    "output": 0.78,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/mai-ds-r1": {
+    "input": 1.35,
+    "output": 5.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/meta-llama-3-70b-instruct": {
+    "input": 2.68,
+    "output": 3.54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/meta-llama-3-8b-instruct": {
+    "input": 0.3,
+    "output": 0.61,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/meta-llama-3.1-405b-instruct": {
+    "input": 5.33,
+    "output": 16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/meta-llama-3.1-70b-instruct": {
+    "input": 2.68,
+    "output": 3.54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/meta-llama-3.1-8b-instruct": {
+    "input": 0.3,
+    "output": 0.61,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/ministral-3b": {
+    "input": 0.04,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/mistral-large-2411": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/mistral-medium-2505": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/mistral-nemo": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/mistral-small-2503": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/model-router": {
+    "input": 0.14,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/o1": {
+    "input": 15,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 7.5
+  },
+  "azure-cognitive-services/o1-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "azure-cognitive-services/o1-preview": {
+    "input": 16.5,
+    "output": 66,
+    "cacheWrite": 0,
+    "cacheRead": 8.25
+  },
+  "azure-cognitive-services/o3": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "azure-cognitive-services/o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "azure-cognitive-services/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.28
+  },
+  "azure-cognitive-services/phi-3-medium-128k-instruct": {
+    "input": 0.17,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-3-medium-4k-instruct": {
+    "input": 0.17,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-3-mini-128k-instruct": {
+    "input": 0.13,
+    "output": 0.52,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-3-mini-4k-instruct": {
+    "input": 0.13,
+    "output": 0.52,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-3-small-128k-instruct": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-3-small-8k-instruct": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-3.5-mini-instruct": {
+    "input": 0.13,
+    "output": 0.52,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-3.5-moe-instruct": {
+    "input": 0.16,
+    "output": 0.64,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-4": {
+    "input": 0.125,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-4-mini": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-4-mini-reasoning": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-4-multimodal": {
+    "input": 0.08,
+    "output": 0.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-4-reasoning": {
+    "input": 0.125,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/phi-4-reasoning-plus": {
+    "input": 0.125,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/text-embedding-3-large": {
+    "input": 0.13,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/text-embedding-3-small": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-cognitive-services/text-embedding-ada-002": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-gpt-4-turbo": {
+    "input": 9.996,
+    "output": 30.005,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-gpt-4o": {
+    "input": 2.499,
+    "output": 9.996,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-gpt-4o-mini": {
+    "input": 0.1496,
+    "output": 0.595,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-o1": {
+    "input": 14.994,
+    "output": 59.993,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure-o3-mini": {
+    "input": 1.088,
+    "output": 4.3996,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/claude-haiku-4-5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "azure/claude-opus-4-1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "azure/claude-opus-4-5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "azure/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "azure/claude-sonnet-4-5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "azure/codestral-2501": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/codex-mini": {
+    "input": 1.5,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.375
+  },
+  "azure/cohere-command-a": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/cohere-command-r-08-2024": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/cohere-command-r-plus-08-2024": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/cohere-embed-v-4-0": {
+    "input": 0.12,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/cohere-embed-v3-english": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/cohere-embed-v3-multilingual": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/deepseek-r1": {
+    "input": 1.35,
+    "output": 5.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/deepseek-r1-0528": {
+    "input": 1.35,
+    "output": 5.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/deepseek-v3-0324": {
+    "input": 1.14,
+    "output": 4.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/deepseek-v3.1": {
+    "input": 0.56,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/deepseek-v3.2": {
+    "input": 0.58,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/deepseek-v3.2-speciale": {
+    "input": 0.58,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/gpt-3.5-turbo-0125": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/gpt-3.5-turbo-0301": {
+    "input": 1.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/gpt-3.5-turbo-0613": {
+    "input": 3,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/gpt-3.5-turbo-1106": {
+    "input": 1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/gpt-3.5-turbo-instruct": {
+    "input": 1.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/gpt-4": {
+    "input": 60,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/gpt-4-32k": {
+    "input": 60,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/gpt-4-turbo": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/gpt-4-turbo-vision": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "azure/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "azure/gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "azure/gpt-4o": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "azure/gpt-4o-mini": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "azure/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "azure/gpt-5-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "azure/gpt-5-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "azure/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "azure/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "azure/gpt-5-pro": {
+    "input": 15,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "azure/gpt-5.1-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "azure/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "azure/gpt-5.1-codex-max": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "azure/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "azure/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "azure/gpt-5.2-chat": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "azure/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "azure/gpt-5.3-chat": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "azure/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "azure/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "azure/gpt-5.4-mini": {
+    "input": 0.75,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "azure/gpt-5.4-nano": {
+    "input": 0.2,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "azure/gpt-5.4-pro": {
+    "input": 30,
+    "output": 180,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/grok-3": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "azure/grok-3-mini": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "azure/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "azure/grok-4-1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "azure/grok-4-1-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "azure/grok-4-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "azure/grok-4-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "azure/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "azure/kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "azure/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/llama-3.2-11b-vision-instruct": {
+    "input": 0.37,
+    "output": 0.37,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/llama-3.2-90b-vision-instruct": {
+    "input": 2.04,
+    "output": 2.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/llama-3.3-70b-instruct": {
+    "input": 0.71,
+    "output": 0.71,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/llama-4-maverick-17b-128e-instruct-fp8": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/llama-4-scout-17b-16e-instruct": {
+    "input": 0.2,
+    "output": 0.78,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/mai-ds-r1": {
+    "input": 1.35,
+    "output": 5.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/meta-llama-3-70b-instruct": {
+    "input": 2.68,
+    "output": 3.54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/meta-llama-3-8b-instruct": {
+    "input": 0.3,
+    "output": 0.61,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/meta-llama-3.1-405b-instruct": {
+    "input": 5.33,
+    "output": 16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/meta-llama-3.1-70b-instruct": {
+    "input": 2.68,
+    "output": 3.54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/meta-llama-3.1-8b-instruct": {
+    "input": 0.3,
+    "output": 0.61,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/ministral-3b": {
+    "input": 0.04,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/mistral-large-2411": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/mistral-medium-2505": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/mistral-nemo": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/mistral-small-2503": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/model-router": {
+    "input": 0.14,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/o1": {
+    "input": 15,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 7.5
+  },
+  "azure/o1-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "azure/o1-preview": {
+    "input": 16.5,
+    "output": 66,
+    "cacheWrite": 0,
+    "cacheRead": 8.25
+  },
+  "azure/o3": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "azure/o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "azure/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.28
+  },
+  "azure/phi-3-medium-128k-instruct": {
+    "input": 0.17,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-3-medium-4k-instruct": {
+    "input": 0.17,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-3-mini-128k-instruct": {
+    "input": 0.13,
+    "output": 0.52,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-3-mini-4k-instruct": {
+    "input": 0.13,
+    "output": 0.52,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-3-small-128k-instruct": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-3-small-8k-instruct": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-3.5-mini-instruct": {
+    "input": 0.13,
+    "output": 0.52,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-3.5-moe-instruct": {
+    "input": 0.16,
+    "output": 0.64,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-4": {
+    "input": 0.125,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-4-mini": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-4-mini-reasoning": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-4-multimodal": {
+    "input": 0.08,
+    "output": 0.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-4-reasoning": {
+    "input": 0.125,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/phi-4-reasoning-plus": {
+    "input": 0.125,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/text-embedding-3-large": {
+    "input": 0.13,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/text-embedding-3-small": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "azure/text-embedding-ada-002": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baichuan-m2": {
+    "input": 15.73,
+    "output": 15.73,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baichuan-m2-32b": {
+    "input": 0.07,
+    "output": 0.07,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baichuan4-air": {
+    "input": 0.157,
+    "output": 0.157,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baichuan4-turbo": {
+    "input": 2.42,
+    "output": 2.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bailing/ling-1t": {
+    "input": 0.57,
+    "output": 2.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bailing/ring-1t": {
+    "input": 0.57,
+    "output": 2.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "balanced": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bart-large-cnn": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "black-forest-labs/flux.2-pro": {
+  "baseten/deepseek-ai/deepseek-v3-0324": {
+    "input": 0.77,
+    "output": 0.77,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baseten/deepseek-ai/deepseek-v3.1": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baseten/deepseek-ai/deepseek-v3.2": {
+    "input": 0.3,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baseten/minimaxai/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baseten/moonshotai/kimi-k2-instruct-0905": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baseten/moonshotai/kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baseten/moonshotai/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baseten/nvidia/nemotron-120b-a12b": {
+    "input": 0.3,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baseten/openai/gpt-oss-120b": {
+    "input": 0.1,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baseten/zai-org/glm-4.6": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baseten/zai-org/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "baseten/zai-org/glm-5": {
+    "input": 0.95,
+    "output": 3.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "berget/baai/bge-reranker-v2-m3": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "berget/intfloat/multilingual-e5-large": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "berget/intfloat/multilingual-e5-large-instruct": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "berget/kblab/kb-whisper-large": {
+    "input": 3,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "berget/meta-llama/llama-3.3-70b-instruct": {
+    "input": 0.9,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "berget/mistralai/mistral-small-3.2-24b-instruct-2506": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "berget/openai/gpt-oss-120b": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "berget/zai-org/glm-4.7": {
+    "input": 0.7,
+    "output": 2.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bge-base-en-v1.5": {
+    "input": 0.067,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bge-en-icl": {
+    "input": 0.01,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bge-large-en-v1.5": {
+    "input": 0.2,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bge-m3": {
+    "input": 0.012,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bge-reranker-base": {
+    "input": 0.0031,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bge-reranker-v2-m3": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bge-small-en-v1.5": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bielik-11b-v2.6-instruct": {
+    "input": 0.67,
+    "output": 0.67,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "bielik-11b-v3.0-instruct": {
+    "input": 0.67,
+    "output": 0.67,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "big-pickle": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "bytedance-seed/seedream-4.5": {
+  "bodybuilder": {
     "input": 0,
     "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "brave": {
+    "input": 5,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "brave-pro": {
+    "input": 5,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "brave-research": {
+    "input": 5,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cerebras-llama-4-maverick-17b-128e-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cerebras-llama-4-scout-17b-16e-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cerebras/gpt-oss-120b": {
+    "input": 0.25,
+    "output": 0.69,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cerebras/llama3.1-8b": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cerebras/qwen-3-235b-a22b-instruct-2507": {
+    "input": 0.6,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cerebras/zai-glm-4.7": {
+    "input": 2.25,
+    "output": 2.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/chutesai/mistral-small-3.1-24b-instruct-2503": {
+    "input": 0.03,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0.015
+  },
+  "chutes/chutesai/mistral-small-3.2-24b-instruct-2506": {
+    "input": 0.06,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/deepseek-ai/deepseek-r1-0528-tee": {
+    "input": 0.4,
+    "output": 1.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/deepseek-ai/deepseek-r1-distill-llama-70b": {
+    "input": 0.03,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/deepseek-ai/deepseek-r1-tee": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/deepseek-ai/deepseek-v3": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/deepseek-ai/deepseek-v3-0324-tee": {
+    "input": 0.19,
+    "output": 0.87,
+    "cacheWrite": 0,
+    "cacheRead": 0.095
+  },
+  "chutes/deepseek-ai/deepseek-v3.1-tee": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/deepseek-ai/deepseek-v3.1-terminus-tee": {
+    "input": 0.23,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/deepseek-ai/deepseek-v3.2-speciale-tee": {
+    "input": 0.27,
+    "output": 0.41,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/deepseek-ai/deepseek-v3.2-tee": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0.14
+  },
+  "chutes/minimaxai/minimax-m2.1-tee": {
+    "input": 0.27,
+    "output": 1.12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/minimaxai/minimax-m2.5-tee": {
+    "input": 0.3,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "chutes/miromind-ai/mirothinker-v1.5-235b": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "chutes/mistralai/devstral-2-123b-instruct-2512-tee": {
+    "input": 0.05,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/moonshotai/kimi-k2-instruct-0905": {
+    "input": 0.39,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0.195
+  },
+  "chutes/moonshotai/kimi-k2-thinking-tee": {
+    "input": 0.4,
+    "output": 1.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/moonshotai/kimi-k2.5-tee": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/nousresearch/deephermes-3-mistral-24b-preview": {
+    "input": 0.02,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/nousresearch/hermes-4-14b": {
+    "input": 0.01,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/nousresearch/hermes-4-405b-fp8-tee": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/nousresearch/hermes-4-70b": {
+    "input": 0.11,
+    "output": 0.38,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/nousresearch/hermes-4.3-36b": {
+    "input": 0.1,
+    "output": 0.39,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/nvidia/nvidia-nemotron-3-nano-30b-a3b-bf16": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/openai/gpt-oss-120b-tee": {
+    "input": 0.04,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/openai/gpt-oss-20b": {
+    "input": 0.02,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/opengvlab/internvl3-78b-tee": {
+    "input": 0.1,
+    "output": 0.39,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen2.5-72b-instruct": {
+    "input": 0.13,
+    "output": 0.52,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen2.5-coder-32b-instruct": {
+    "input": 0.03,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen2.5-vl-32b-instruct": {
+    "input": 0.05,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen2.5-vl-72b-instruct-tee": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen3-14b": {
+    "input": 0.05,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen3-235b-a22b": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen3-235b-a22b-instruct-2507-tee": {
+    "input": 0.08,
+    "output": 0.55,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "chutes/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.11,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen3-30b-a3b": {
+    "input": 0.06,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen3-30b-a3b-instruct-2507": {
+    "input": 0.08,
+    "output": 0.33,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen3-32b": {
+    "input": 0.08,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "chutes/qwen/qwen3-coder-480b-a35b-instruct-fp8-tee": {
+    "input": 0.22,
+    "output": 0.95,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "chutes/qwen/qwen3-coder-next": {
+    "input": 0.07,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen3-next-80b-a3b-instruct": {
+    "input": 0.1,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen3-vl-235b-a22b-instruct": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/qwen/qwen3.5-397b-a17b-tee": {
+    "input": 0.39,
+    "output": 2.34,
+    "cacheWrite": 0,
+    "cacheRead": 0.195
+  },
+  "chutes/qwen/qwen3guard-gen-0.6b": {
+    "input": 0.01,
+    "output": 0.01,
+    "cacheWrite": 0,
+    "cacheRead": 0.005
+  },
+  "chutes/rednote-hilab/dots.ocr": {
+    "input": 0.01,
+    "output": 0.01,
+    "cacheWrite": 0,
+    "cacheRead": 0.005
+  },
+  "chutes/tngtech/deepseek-r1t-chimera": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/tngtech/deepseek-tng-r1t2-chimera": {
+    "input": 0.25,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/tngtech/tng-r1t-chimera-tee": {
+    "input": 0.25,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/tngtech/tng-r1t-chimera-turbo": {
+    "input": 0.22,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/unsloth/gemma-3-12b-it": {
+    "input": 0.03,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/unsloth/gemma-3-27b-it": {
+    "input": 0.04,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "chutes/unsloth/gemma-3-4b-it": {
+    "input": 0.01,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/unsloth/llama-3.2-1b-instruct": {
+    "input": 0.01,
+    "output": 0.01,
+    "cacheWrite": 0,
+    "cacheRead": 0.005
+  },
+  "chutes/unsloth/llama-3.2-3b-instruct": {
+    "input": 0.01,
+    "output": 0.01,
+    "cacheWrite": 0,
+    "cacheRead": 0.005
+  },
+  "chutes/unsloth/mistral-nemo-instruct-2407": {
+    "input": 0.02,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "chutes/unsloth/mistral-small-24b-instruct-2501": {
+    "input": 0.03,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/xiaomimimo/mimo-v2-flash": {
+    "input": 0.09,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/zai-org/glm-4.5-air": {
+    "input": 0.05,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/zai-org/glm-4.5-fp8": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/zai-org/glm-4.5-tee": {
+    "input": 0.35,
+    "output": 1.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/zai-org/glm-4.6-fp8": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/zai-org/glm-4.6-tee": {
+    "input": 0.4,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "chutes/zai-org/glm-4.6v": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "chutes/zai-org/glm-4.7-flash": {
+    "input": 0.06,
+    "output": 0.35,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/zai-org/glm-4.7-fp8": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/zai-org/glm-4.7-tee": {
+    "input": 0.4,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "chutes/zai-org/glm-5-tee": {
+    "input": 0.95,
+    "output": 3.15,
+    "cacheWrite": 0,
+    "cacheRead": 0.475
+  },
+  "chutes/zai-org/glm-5-turbo": {
+    "input": 0.49,
+    "output": 1.96,
+    "cacheWrite": 0,
+    "cacheRead": 0.245
+  },
+  "clarifai/arcee_ai/afm/models/trinity-mini": {
+    "input": 0.045,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "clarifai/clarifai/main/models/mm-poly-8b": {
+    "input": 0.658,
+    "output": 1.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "clarifai/deepseek-ai/deepseek-ocr/models/deepseek-ocr": {
+    "input": 0.2,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "clarifai/minimaxai/chat-completion/models/minimax-m2_5-high-throughput": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "clarifai/mistralai/completion/models/ministral-3-14b-reasoning-2512": {
+    "input": 2.5,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "clarifai/mistralai/completion/models/ministral-3-3b-reasoning-2512": {
+    "input": 1.039,
+    "output": 0.54825,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "clarifai/openai/chat-completion/models/gpt-oss-120b-high-throughput": {
+    "input": 0.09,
+    "output": 0.36,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "clarifai/openai/chat-completion/models/gpt-oss-20b": {
+    "input": 0.045,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "clarifai/qwen/qwencoder/models/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.11458,
+    "output": 0.74812,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "clarifai/qwen/qwenlm/models/qwen3-30b-a3b-instruct-2507": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "clarifai/qwen/qwenlm/models/qwen3-30b-a3b-thinking-2507": {
+    "input": 0.36,
+    "output": 1.3,
     "cacheWrite": 0,
     "cacheRead": 0
   },
@@ -113,6 +4811,18 @@
     "cacheWrite": 1,
     "cacheRead": 0.08
   },
+  "claude-3-5-haiku@20241022": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "claude-3-5-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
   "claude-3-5-sonnet-20240620": {
     "input": 3,
     "output": 15,
@@ -125,6 +4835,12 @@
     "cacheWrite": 3.75,
     "cacheRead": 0.3
   },
+  "claude-3-5-sonnet@20241022": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
   "claude-3-7-sonnet-20250219": {
     "input": 3,
     "output": 15,
@@ -132,28 +4848,58 @@
     "cacheRead": 0.3
   },
   "claude-3-7-sonnet-latest": {
+    "input": 3.3,
+    "output": 16.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.33
+  },
+  "claude-3-7-sonnet-reasoner": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-3-7-sonnet-thinking": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-3-7-sonnet-thinking:1024": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-3-7-sonnet-thinking:128000": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-3-7-sonnet-thinking:32768": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-3-7-sonnet-thinking:8192": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-3-7-sonnet@20250219": {
     "input": 3,
     "output": 15,
     "cacheWrite": 3.75,
     "cacheRead": 0.3
-  },
-  "claude-3-haiku": {
-    "input": 0.25,
-    "output": 1.25,
-    "cacheWrite": 0.3,
-    "cacheRead": 0.03
   },
   "claude-3-haiku-20240307": {
     "input": 0.25,
     "output": 1.25,
     "cacheWrite": 0.3,
     "cacheRead": 0.03
-  },
-  "claude-3-opus": {
-    "input": 15,
-    "output": 75,
-    "cacheWrite": 18.75,
-    "cacheRead": 1.5
   },
   "claude-3-opus-20240229": {
     "input": 15,
@@ -164,13 +4910,13 @@
   "claude-3-sonnet": {
     "input": 3,
     "output": 15,
-    "cacheWrite": 3.75,
+    "cacheWrite": 0.3,
     "cacheRead": 0.3
   },
   "claude-3-sonnet-20240229": {
     "input": 3,
     "output": 15,
-    "cacheWrite": 3.75,
+    "cacheWrite": 0.3,
     "cacheRead": 0.3
   },
   "claude-3.5-haiku": {
@@ -179,17 +4925,71 @@
     "cacheWrite": 1,
     "cacheRead": 0.08
   },
-  "claude-3.5-sonnet": {
+  "claude-3.5-sonnet-20240620": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-3.5-sonnet-v2": {
     "input": 3,
     "output": 15,
     "cacheWrite": 3.75,
     "cacheRead": 0.3
   },
-  "claude-3.7-sonnet": {
+  "claude-3.7-sonnet:thinking": {
     "input": 3,
     "output": 15,
     "cacheWrite": 3.75,
     "cacheRead": 0.3
+  },
+  "claude-4-5-sonnet": {
+    "input": 3.259,
+    "output": 16.296,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-4-6-sonnet": {
+    "input": 3.59,
+    "output": 17.92,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-4-opus": {
+    "input": 16.5,
+    "output": 82.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-4.5-haiku": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "claude-4.5-opus": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "claude-4.5-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "claude-haiku-3": {
+    "input": 0.21,
+    "output": 1.1,
+    "cacheWrite": 0.26,
+    "cacheRead": 0.021
+  },
+  "claude-haiku-3.5": {
+    "input": 0.68,
+    "output": 3.4,
+    "cacheWrite": 0.85,
+    "cacheRead": 0.068
   },
   "claude-haiku-4-5": {
     "input": 1,
@@ -203,17 +5003,11 @@
     "cacheWrite": 1.25,
     "cacheRead": 0.1
   },
-  "claude-haiku-4.5": {
+  "claude-haiku-4-5@20251001": {
     "input": 1,
     "output": 5,
     "cacheWrite": 1.25,
     "cacheRead": 0.1
-  },
-  "claude-opus-4": {
-    "input": 15,
-    "output": 75,
-    "cacheWrite": 18.75,
-    "cacheRead": 1.5
   },
   "claude-opus-4-0": {
     "input": 15,
@@ -228,6 +5022,48 @@
     "cacheRead": 1.5
   },
   "claude-opus-4-1-20250805": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "claude-opus-4-1-20250805-thinking": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-1-thinking": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-1-thinking:1024": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-1-thinking:32000": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-1-thinking:32768": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-1-thinking:8192": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-1@20250805": {
     "input": 15,
     "output": 75,
     "cacheWrite": 18.75,
@@ -251,29 +5087,95 @@
     "cacheWrite": 6.25,
     "cacheRead": 0.5
   },
+  "claude-opus-4-5-20251101-thinking": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-5-20251101:thinking": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-5@20251101": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
   "claude-opus-4-6": {
     "input": 5,
     "output": 25,
     "cacheWrite": 6.25,
     "cacheRead": 0.5
   },
-  "claude-opus-4.1": {
-    "input": 15,
-    "output": 75,
-    "cacheWrite": 18.75,
-    "cacheRead": 1.5
+  "claude-opus-4-6-think": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
   },
-  "claude-opus-4.5": {
+  "claude-opus-4-6@default": {
     "input": 5,
     "output": 25,
     "cacheWrite": 6.25,
     "cacheRead": 0.5
   },
-  "claude-opus-4.6": {
-    "input": 5,
-    "output": 25,
-    "cacheWrite": 6.25,
-    "cacheRead": 0.5
+  "claude-opus-4-thinking": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-thinking:1024": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-thinking:32000": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-thinking:32768": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4-thinking:8192": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4.6:thinking": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4.6:thinking:low": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4.6:thinking:max": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus-4.6:thinking:medium": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
   },
   "claude-opus-41": {
     "input": 0,
@@ -281,11 +5183,47 @@
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "claude-sonnet-4": {
-    "input": 3,
-    "output": 15,
-    "cacheWrite": 3.75,
-    "cacheRead": 0.3
+  "claude-opus-45": {
+    "input": 6,
+    "output": 30,
+    "cacheWrite": 7.5,
+    "cacheRead": 0.6
+  },
+  "claude-opus-4@20250514": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "claude-opus4-5": {
+    "input": 5.98,
+    "output": 29.89,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-opus4-6": {
+    "input": 5.98,
+    "output": 29.89,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-sonnet-3.5": {
+    "input": 2.6,
+    "output": 13,
+    "cacheWrite": 3.2,
+    "cacheRead": 0.26
+  },
+  "claude-sonnet-3.5-june": {
+    "input": 2.6,
+    "output": 13,
+    "cacheWrite": 3.2,
+    "cacheRead": 0.26
+  },
+  "claude-sonnet-3.7": {
+    "input": 2.6,
+    "output": 13,
+    "cacheWrite": 3.2,
+    "cacheRead": 0.26
   },
   "claude-sonnet-4-0": {
     "input": 3,
@@ -311,11 +5249,851 @@
     "cacheWrite": 3.75,
     "cacheRead": 0.3
   },
-  "claude-sonnet-4.5": {
+  "claude-sonnet-4-5@20250929": {
     "input": 3,
     "output": 15,
     "cacheWrite": 3.75,
     "cacheRead": 0.3
+  },
+  "claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "claude-sonnet-4-6-think": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "claude-sonnet-4-6@default": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "claude-sonnet-4-thinking": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-sonnet-4-thinking:1024": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-sonnet-4-thinking:32768": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-sonnet-4-thinking:64000": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-sonnet-4-thinking:8192": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-sonnet-4.6:thinking": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "claude-sonnet-45": {
+    "input": 3.75,
+    "output": 18.75,
+    "cacheWrite": 4.69,
+    "cacheRead": 0.375
+  },
+  "claude-sonnet-4@20250514": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "cloudferro-sherlock/meta-llama/llama-3.3-70b-instruct": {
+    "input": 2.92,
+    "output": 2.92,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudferro-sherlock/minimaxai/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudferro-sherlock/openai/gpt-oss-120b": {
+    "input": 2.92,
+    "output": 2.92,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudferro-sherlock/speakleash/bielik-11b-v2.6-instruct": {
+    "input": 0.67,
+    "output": 0.67,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudferro-sherlock/speakleash/bielik-11b-v3.0-instruct": {
+    "input": 0.67,
+    "output": 0.67,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/anthropic/claude-3-5-haiku": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "cloudflare-ai-gateway/anthropic/claude-3-haiku": {
+    "input": 0.25,
+    "output": 1.25,
+    "cacheWrite": 0.3,
+    "cacheRead": 0.03
+  },
+  "cloudflare-ai-gateway/anthropic/claude-3-opus": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "cloudflare-ai-gateway/anthropic/claude-3-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0.3,
+    "cacheRead": 0.3
+  },
+  "cloudflare-ai-gateway/anthropic/claude-3.5-haiku": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "cloudflare-ai-gateway/anthropic/claude-3.5-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "cloudflare-ai-gateway/anthropic/claude-haiku-4-5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "cloudflare-ai-gateway/anthropic/claude-opus-4": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "cloudflare-ai-gateway/anthropic/claude-opus-4-1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "cloudflare-ai-gateway/anthropic/claude-opus-4-5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "cloudflare-ai-gateway/anthropic/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "cloudflare-ai-gateway/anthropic/claude-sonnet-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "cloudflare-ai-gateway/anthropic/claude-sonnet-4-5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "cloudflare-ai-gateway/anthropic/claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "cloudflare-ai-gateway/openai/gpt-3.5-turbo": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "cloudflare-ai-gateway/openai/gpt-4": {
+    "input": 30,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/openai/gpt-4-turbo": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/openai/gpt-4o": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "cloudflare-ai-gateway/openai/gpt-4o-mini": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "cloudflare-ai-gateway/openai/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "cloudflare-ai-gateway/openai/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "cloudflare-ai-gateway/openai/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "cloudflare-ai-gateway/openai/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "cloudflare-ai-gateway/openai/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "cloudflare-ai-gateway/openai/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "cloudflare-ai-gateway/openai/o1": {
+    "input": 15,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 7.5
+  },
+  "cloudflare-ai-gateway/openai/o3": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "cloudflare-ai-gateway/openai/o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "cloudflare-ai-gateway/openai/o3-pro": {
+    "input": 20,
+    "output": 80,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/openai/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.28
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/ai4bharat/indictrans2-en-indic-1b": {
+    "input": 0.34,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
+    "input": 0.35,
+    "output": 0.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/baai/bge-base-en-v1.5": {
+    "input": 0.067,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/baai/bge-large-en-v1.5": {
+    "input": 0.2,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/baai/bge-m3": {
+    "input": 0.012,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/baai/bge-reranker-base": {
+    "input": 0.0031,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/baai/bge-small-en-v1.5": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/deepgram/aura-2-en": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/deepgram/aura-2-es": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/deepgram/nova-3": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+    "input": 0.5,
+    "output": 4.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/facebook/bart-large-cnn": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/google/gemma-3-12b-it": {
+    "input": 0.35,
+    "output": 0.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/huggingface/distilbert-sst-2-int8": {
+    "input": 0.026,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/ibm-granite/granite-4.0-h-micro": {
+    "input": 0.017,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-2-7b-chat-fp16": {
+    "input": 0.56,
+    "output": 6.67,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3-8b-instruct": {
+    "input": 0.28,
+    "output": 0.83,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3-8b-instruct-awq": {
+    "input": 0.12,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct": {
+    "input": 0.28,
+    "output": 0.83,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct-awq": {
+    "input": 0.12,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct-fp8": {
+    "input": 0.15,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.2-11b-vision-instruct": {
+    "input": 0.049,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.2-1b-instruct": {
+    "input": 0.027,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.2-3b-instruct": {
+    "input": 0.051,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
+    "input": 0.29,
+    "output": 2.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-4-scout-17b-16e-instruct": {
+    "input": 0.27,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-guard-3-8b": {
+    "input": 0.48,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/meta/m2m100-1.2b": {
+    "input": 0.34,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/mistral/mistral-7b-instruct-v0.1": {
+    "input": 0.11,
+    "output": 0.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/mistralai/mistral-small-3.1-24b-instruct": {
+    "input": 0.35,
+    "output": 0.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/myshell-ai/melotts": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/nvidia/nemotron-3-120b-a12b": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/openai/gpt-oss-120b": {
+    "input": 0.35,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/openai/gpt-oss-20b": {
+    "input": 0.2,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/pfnet/plamo-embedding-1b": {
+    "input": 0.019,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/pipecat-ai/smart-turn-v2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/qwen/qwen2.5-coder-32b-instruct": {
+    "input": 0.66,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/qwen/qwen3-30b-a3b-fp8": {
+    "input": 0.051,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/qwen/qwen3-embedding-0.6b": {
+    "input": 0.012,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/qwen/qwq-32b": {
+    "input": 0.66,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-ai-gateway/workers-ai/@cf/zai-org/glm-4.7-flash": {
+    "input": 0.06,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/ai4bharat/indictrans2-en-indic-1b": {
+    "input": 0.34,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
+    "input": 0.35,
+    "output": 0.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/baai/bge-base-en-v1.5": {
+    "input": 0.067,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/baai/bge-large-en-v1.5": {
+    "input": 0.2,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/baai/bge-m3": {
+    "input": 0.012,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/baai/bge-reranker-base": {
+    "input": 0.0031,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/baai/bge-small-en-v1.5": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/deepgram/aura-2-en": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/deepgram/aura-2-es": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/deepgram/nova-3": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+    "input": 0.5,
+    "output": 4.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/facebook/bart-large-cnn": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/google/gemma-3-12b-it": {
+    "input": 0.35,
+    "output": 0.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/huggingface/distilbert-sst-2-int8": {
+    "input": 0.026,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/ibm-granite/granite-4.0-h-micro": {
+    "input": 0.017,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-2-7b-chat-fp16": {
+    "input": 0.56,
+    "output": 6.67,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-3-8b-instruct": {
+    "input": 0.28,
+    "output": 0.83,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-3-8b-instruct-awq": {
+    "input": 0.12,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-3.1-8b-instruct": {
+    "input": 0.28,
+    "output": 0.83,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-3.1-8b-instruct-awq": {
+    "input": 0.12,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-3.1-8b-instruct-fp8": {
+    "input": 0.15,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-3.2-11b-vision-instruct": {
+    "input": 0.049,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-3.2-1b-instruct": {
+    "input": 0.027,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-3.2-3b-instruct": {
+    "input": 0.051,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
+    "input": 0.29,
+    "output": 2.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-4-scout-17b-16e-instruct": {
+    "input": 0.27,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/llama-guard-3-8b": {
+    "input": 0.48,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/meta/m2m100-1.2b": {
+    "input": 0.34,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/mistral/mistral-7b-instruct-v0.1": {
+    "input": 0.11,
+    "output": 0.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/mistralai/mistral-small-3.1-24b-instruct": {
+    "input": 0.35,
+    "output": 0.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/moonshotai/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "cloudflare-workers-ai/@cf/myshell-ai/melotts": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/nvidia/nemotron-3-120b-a12b": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/openai/gpt-oss-120b": {
+    "input": 0.35,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/openai/gpt-oss-20b": {
+    "input": 0.2,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/pfnet/plamo-embedding-1b": {
+    "input": 0.019,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/pipecat-ai/smart-turn-v2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/qwen/qwen2.5-coder-32b-instruct": {
+    "input": 0.66,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/qwen/qwen3-30b-a3b-fp8": {
+    "input": 0.051,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/qwen/qwen3-embedding-0.6b": {
+    "input": 0.012,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/qwen/qwq-32b": {
+    "input": 0.66,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cloudflare-workers-ai/@cf/zai-org/glm-4.7-flash": {
+    "input": 0.06,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "codegemma-1.1-7b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "codegemma-7b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "codellama-70b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "codellama-7b-instruct-solidity": {
+    "input": 0.8,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "coder-large": {
+    "input": 0.5,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "codestral": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "codestral-22b-instruct-v0.1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "codestral-2508": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "codestral-embed": {
+    "input": 0.15,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "codestral-latest": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
   },
   "codex-mini-latest": {
     "input": 1.5,
@@ -323,123 +6101,1857 @@
     "cacheWrite": 0,
     "cacheRead": 0.375
   },
-  "cognitivecomputations/dolphin-mistral-24b-venice-edition:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "cognitivecomputations/dolphin3.0-mistral-24b": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "cognitivecomputations/dolphin3.0-r1-mistral-24b": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "deepseek-r1": {
-    "input": 0.55,
-    "output": 2.19,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "deepseek-v2": {
-    "input": 0.14,
-    "output": 0.28,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "deepseek-v3": {
+  "coding-glm-4.7": {
     "input": 0.27,
     "output": 1.1,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 0.548
   },
-  "deepseek/deepseek-chat-v3-0324": {
+  "coding-glm-4.7-free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "deepseek/deepseek-chat-v3.1": {
+  "coding-glm-5-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "coding-minimax-m2.1-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cogito-v1-preview-qwen-32b": {
+    "input": 1.8,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cogito-v2.1-671b": {
+    "input": 1.25,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cogview-4": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere-command-r": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere-command-r-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere-embed-v-4-0": {
+    "input": 0.12,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere-embed-v3-english": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere-embed-v3-multilingual": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere/command-a-03-2025": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere/command-a-reasoning-08-2025": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere/command-a-translate-08-2025": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere/command-a-vision-07-2025": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere/command-r-08-2024": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere/command-r-plus-08-2024": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere/command-r7b-12-2024": {
+    "input": 0.0375,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cohere/command-r7b-arabic-02-2025": {
+    "input": 0.0375,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "command-a": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "command-a-03-2025": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "command-a-reasoning-08-2025": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "command-a-translate-08-2025": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "command-a-vision-07-2025": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "command-r": {
+    "input": 0.476,
+    "output": 1.428,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "command-r-08-2024": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "command-r-plus-08-2024": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "command-r7b-12-2024": {
+    "input": 0.0375,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "command-r7b-arabic-02-2025": {
+    "input": 0.0375,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "compound": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "compound-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "corethink:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/claude-4-5-sonnet": {
+    "input": 3.259,
+    "output": 16.296,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/claude-4-6-sonnet": {
+    "input": 3.59,
+    "output": 17.92,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/claude-haiku-4-5": {
+    "input": 1.09,
+    "output": 5.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/claude-opus4-5": {
+    "input": 5.98,
+    "output": 29.89,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/claude-opus4-6": {
+    "input": 5.98,
+    "output": 29.89,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/claude-sonnet-4": {
+    "input": 3.307,
+    "output": 16.536,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/deepseek-v3-0324": {
+    "input": 0.551,
+    "output": 1.654,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/devstral-2512": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/devstral-small-2512": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/gemini-2.5-pro": {
+    "input": 1.654,
+    "output": 11.024,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/glm-4.5": {
+    "input": 0.67,
+    "output": 2.46,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/glm-4.5-air": {
+    "input": 0.22,
+    "output": 1.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/glm-4.7": {
+    "input": 0.45,
+    "output": 2.23,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/glm-4.7-flash": {
+    "input": 0.09,
+    "output": 0.53,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/glm-5": {
+    "input": 1.08,
+    "output": 3.44,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/gpt-4.1": {
+    "input": 2.354,
+    "output": 9.417,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/gpt-oss-120b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/intellect-3": {
+    "input": 0.219,
+    "output": 1.202,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/kimi-k2-instruct": {
+    "input": 0.551,
+    "output": 2.646,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/kimi-k2-thinking": {
+    "input": 0.656,
+    "output": 2.731,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/kimi-k2.5": {
+    "input": 0.55,
+    "output": 2.76,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/llama-3.1-405b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/minimax-m2": {
+    "input": 0.39,
+    "output": 1.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/minimax-m2.1": {
+    "input": 0.34,
+    "output": 1.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/minimax-m2.5": {
+    "input": 0.32,
+    "output": 1.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/nova-pro-v1": {
+    "input": 1.016,
+    "output": 4.061,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/qwen3-32b": {
+    "input": 0.099,
+    "output": 0.33,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.441,
+    "output": 1.984,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cortecs/qwen3-next-80b-a3b-thinking": {
+    "input": 0.164,
+    "output": 1.311,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cosmos-nemotron-34b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "custom": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cydonia-24b-v2": {
+    "input": 0.1003,
+    "output": 0.1207,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cydonia-24b-v4": {
+    "input": 0.2006,
+    "output": 0.2414,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "cydonia-24b-v4.3": {
+    "input": 0.1003,
+    "output": 0.1207,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepclaude": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/anthropic/claude-3-7-sonnet-latest": {
+    "input": 3.3,
+    "output": 16.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.33
+  },
+  "deepinfra/anthropic/claude-4-opus": {
+    "input": 16.5,
+    "output": 82.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/deepseek-ai/deepseek-r1-0528": {
+    "input": 0.5,
+    "output": 2.15,
+    "cacheWrite": 0,
+    "cacheRead": 0.35
+  },
+  "deepinfra/deepseek-ai/deepseek-v3.2": {
+    "input": 0.26,
+    "output": 0.38,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "deepinfra/meta-llama/llama-3.1-70b-instruct": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/meta-llama/llama-3.1-70b-instruct-turbo": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/meta-llama/llama-3.1-8b-instruct": {
+    "input": 0.02,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/meta-llama/llama-3.1-8b-instruct-turbo": {
+    "input": 0.02,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/meta-llama/llama-3.3-70b-instruct-turbo": {
+    "input": 0.1,
+    "output": 0.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/meta-llama/llama-4-scout-17b-16e-instruct": {
+    "input": 0.08,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/minimaxai/minimax-m2": {
+    "input": 0.254,
+    "output": 1.02,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/minimaxai/minimax-m2.1": {
+    "input": 0.28,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/minimaxai/minimax-m2.5": {
+    "input": 0.27,
+    "output": 0.95,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.03
+  },
+  "deepinfra/moonshotai/kimi-k2-instruct": {
+    "input": 0.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/moonshotai/kimi-k2-instruct-0905": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "deepinfra/moonshotai/kimi-k2-thinking": {
+    "input": 0.47,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/moonshotai/kimi-k2.5": {
+    "input": 0.5,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/openai/gpt-oss-120b": {
+    "input": 0.05,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/openai/gpt-oss-20b": {
+    "input": 0.03,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/qwen/qwen3-coder-480b-a35b-instruct-turbo": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/zai-org/glm-4.5": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/zai-org/glm-4.6": {
+    "input": 0.43,
+    "output": 1.74,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "deepinfra/zai-org/glm-4.6v": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/zai-org/glm-4.7": {
+    "input": 0.43,
+    "output": 1.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "deepinfra/zai-org/glm-4.7-flash": {
+    "input": 0.06,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepinfra/zai-org/glm-5": {
+    "input": 0.8,
+    "output": 2.56,
+    "cacheWrite": 0,
+    "cacheRead": 0.16
+  },
+  "deepseek-chat": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0.028
+  },
+  "deepseek-chat-cheaper": {
+    "input": 0.25,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-chat-v3-0324": {
+    "input": 0.2,
+    "output": 0.77,
+    "cacheWrite": 0,
+    "cacheRead": 0.095
+  },
+  "deepseek-coder-6.7b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-math-v2": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-ocr-2": {
+    "input": 0.03,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1-0528-fast": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1-0528-qwen3-8b": {
+    "input": 0.06,
+    "output": 0.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1-0528-tee": {
+    "input": 0.4,
+    "output": 1.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1-distill-llama-70b-abliterated": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1-distill-llama-8b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1-distill-qwen-1-5b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1-distill-qwen-32b-abliterated": {
+    "input": 1.4,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1-distill-qwen-7b": {
+    "input": 0.072,
+    "output": 0.144,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1-sambanova": {
+    "input": 4.998,
+    "output": 6.987,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1-tee": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1-turbo": {
+    "input": 0.7,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1t-chimera": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-r1t2-chimera": {
+    "input": 0.25,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "deepseek-reasoner": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0.028
+  },
+  "deepseek-reasoner-cheaper": {
+    "input": 0.4,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-v3-0324-fast": {
+    "input": 0.75,
+    "output": 2.25,
+    "cacheWrite": 0.28125,
+    "cacheRead": 0.075
+  },
+  "deepseek-v3-0324-tee": {
+    "input": 0.19,
+    "output": 0.87,
+    "cacheWrite": 0,
+    "cacheRead": 0.095
+  },
+  "deepseek-v3-2": {
+    "input": 0.58,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0.28
+  },
+  "deepseek-v3-2-exp": {
+    "input": 0.287,
+    "output": 0.431,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-v3-turbo": {
+    "input": 0.4,
+    "output": 1.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-v3.1-maas": {
+    "input": 0.6,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-v3.1-tee": {
     "input": 0.2,
     "output": 0.8,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "deepseek/deepseek-r1-0528-qwen3-8b:free": {
-    "input": 0,
-    "output": 0,
+  "deepseek-v3.1-terminus-tee": {
+    "input": 0.23,
+    "output": 0.9,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "deepseek/deepseek-r1-0528:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "deepseek/deepseek-r1-distill-llama-70b": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "deepseek/deepseek-r1-distill-qwen-14b": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "deepseek/deepseek-r1:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "deepseek/deepseek-v3-base:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "deepseek/deepseek-v3.1-terminus": {
+  "deepseek-v3.1-terminus:exacto": {
     "input": 0.27,
     "output": 1,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "deepseek/deepseek-v3.1-terminus:exacto": {
-    "input": 0.27,
-    "output": 1,
+  "deepseek-v3.1-terminus:thinking": {
+    "input": 0.25,
+    "output": 0.7,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "deepseek/deepseek-v3.2": {
+  "deepseek-v3.1:thinking": {
+    "input": 0.2,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-v3.2-exp-thinking": {
     "input": 0.28,
-    "output": 0.4,
+    "output": 0.42,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "deepseek/deepseek-v3.2-speciale": {
+  "deepseek-v3.2-fast": {
+    "input": 1.1,
+    "output": 3.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-v3.2-speciale-tee": {
     "input": 0.27,
     "output": 0.41,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "default": {
+  "deepseek-v3.2-tee": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0.14
+  },
+  "deepseek-v3.2-think": {
+    "input": 0.3,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-v3.2:thinking": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-v3p1": {
+    "input": 0.56,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek-v3p2": {
+    "input": 0.56,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0.28
+  },
+  "deepseek-vl2": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek.r1-v1:0": {
+    "input": 1.35,
+    "output": 5.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek.v3-v1:0": {
+    "input": 0.58,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek.v3.2": {
+    "input": 0.62,
+    "output": 1.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "deepseek/deepseek-chat": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0.028
+  },
+  "deepseek/deepseek-reasoner": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0.028
+  },
+  "devstral-2-123b-instruct-2512-tee": {
+    "input": 0.05,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "devstral-medium": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "devstral-medium-2507": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "devstral-medium-latest": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "devstral-small": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "devstral-small-2-24b-instruct-2512": {
+    "input": 0.12,
+    "output": 0.47,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "devstral-small-2507": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "devstral-small-2512": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "dinference/glm-4.7": {
+    "input": 0.45,
+    "output": 1.65,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "dinference/glm-5": {
+    "input": 0.75,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "dinference/gpt-oss-120b": {
+    "input": 0.0675,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "distilbert-sst-2-int8": {
+    "input": 0.026,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "dmind-1": {
+    "input": 0.3,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "dmind-1-mini": {
+    "input": 0.2,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "dolphin-2.9.2-qwen2-72b": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "dolphin-mistral-24b-venice-edition:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "dots.ocr": {
+    "input": 0.01,
+    "output": 0.01,
+    "cacheWrite": 0,
+    "cacheRead": 0.005
+  },
+  "doubao-1-5-thinking-pro-250415": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-1-5-thinking-pro-vision-250415": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-1-5-thinking-vision-pro-250428": {
+    "input": 0.55,
+    "output": 1.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-1.5-pro-256k": {
+    "input": 0.799,
+    "output": 1.445,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-1.5-pro-32k": {
+    "input": 0.1343,
+    "output": 0.3349,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-1.5-vision-pro-32k": {
+    "input": 0.459,
+    "output": 1.377,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-1-6-250615": {
+    "input": 0.204,
+    "output": 0.51,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-1-6-flash-250615": {
+    "input": 0.0374,
+    "output": 0.374,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-1-6-thinking-250615": {
+    "input": 0.204,
+    "output": 2.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-1-6-thinking-250715": {
+    "input": 0.121,
+    "output": 1.21,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-1-6-vision-250815": {
+    "input": 0.114,
+    "output": 1.143,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-1.8": {
+    "input": 0.11,
+    "output": 0.28,
+    "cacheWrite": 0.0024,
+    "cacheRead": 0.02
+  },
+  "doubao-seed-2-0-code-preview-260215": {
+    "input": 0.782,
+    "output": 3.893,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-2-0-lite-260215": {
+    "input": 0.1462,
+    "output": 0.8738,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-2-0-mini-260215": {
+    "input": 0.0493,
+    "output": 0.4845,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-2-0-pro-260215": {
+    "input": 0.782,
+    "output": 3.876,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-2.0-code": {
+    "input": 0.9,
+    "output": 4.48,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-2.0-lite": {
+    "input": 0.09,
+    "output": 0.51,
+    "cacheWrite": 0.0024,
+    "cacheRead": 0.02
+  },
+  "doubao-seed-2.0-mini": {
+    "input": 0.03,
+    "output": 0.28,
+    "cacheWrite": 0.0024,
+    "cacheRead": 0.01
+  },
+  "doubao-seed-2.0-pro": {
+    "input": 0.45,
+    "output": 2.24,
+    "cacheWrite": 0.0024,
+    "cacheRead": 0.09
+  },
+  "doubao-seed-code": {
+    "input": 0.17,
+    "output": 1.12,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "doubao-seed-code-preview-251028": {
+    "input": 0.17,
+    "output": 1.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "doubao-seed-code-preview-latest": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "dracarys-72b-instruct": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "drun/public/deepseek-r1": {
+    "input": 0.55,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "drun/public/deepseek-v3": {
+    "input": 0.28,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "drun/public/minimax-m25": {
+    "input": 0.29,
+    "output": 1.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-gpt-5-1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-gpt-5-2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-gpt-5-2-codex": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-gpt-5-3-codex": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-gpt-5-4": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-gpt-5-4-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-gpt-5-4-nano": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-gpt-5-codex": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-gpt-5-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-haiku-4-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-opus-4-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-opus-4-6": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-sonnet-4-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "duo-chat-sonnet-4-6": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "embed-v4.0": {
+    "input": 0.12,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-4.5-21b-a3b": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-4.5-21b-a3b-thinking": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-4.5-300b-a47b-paddle": {
+    "input": 0.28,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-4.5-8k-preview": {
+    "input": 0.66,
+    "output": 2.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-4.5-turbo-128k": {
+    "input": 0.132,
+    "output": 0.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-4.5-turbo-vl-32k": {
+    "input": 0.495,
+    "output": 1.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-4.5-vl-28b-a3b-thinking": {
+    "input": 0.39,
+    "output": 0.39,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-4.5-vl-424b-a47b": {
+    "input": 0.42,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-5.0-thinking-latest": {
+    "input": 1.1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-x1-32k": {
+    "input": 0.33,
+    "output": 1.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-x1-32k-preview": {
+    "input": 0.33,
+    "output": 1.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-x1-turbo-32k": {
+    "input": 0.165,
+    "output": 0.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ernie-x1.1-preview": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "eu.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "eu.anthropic.claude-opus-4-6-v1": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "eu.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "eu.anthropic.claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "eva-llama-3.33-70b-v0.0": {
+    "input": 2.006,
+    "output": 2.006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "eva-llama-3.33-70b-v0.1": {
+    "input": 2.006,
+    "output": 2.006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "eva-qwen2.5-32b-v0.2": {
+    "input": 0.799,
+    "output": 0.799,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "eva-qwen2.5-72b-v0.2": {
+    "input": 0.799,
+    "output": 0.799,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/intfloat/multilingual-e5-large-instruct": {
+    "input": 0.12,
+    "output": 0.12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/kblab/kb-whisper-large": {
+    "input": 0.00236,
+    "output": 0.00236,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/microsoft/phi-4-multimodal-instruct": {
+    "input": 0.24,
+    "output": 0.47,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/mistralai/devstral-small-2-24b-instruct-2512": {
+    "input": 0.12,
+    "output": 0.47,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/mistralai/magistral-small-2509": {
+    "input": 0.59,
+    "output": 2.36,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/mistralai/voxtral-small-24b-2507": {
+    "input": 0.00236,
+    "output": 0.00236,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/moonshotai/kimi-k2.5": {
+    "input": 1.47,
+    "output": 5.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/nvidia/llama-3.3-70b-instruct-fp8": {
+    "input": 1.18,
+    "output": 1.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/openai/gpt-oss-120b": {
+    "input": 0.24,
+    "output": 0.94,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/openai/whisper-large-v3": {
+    "input": 0.00236,
+    "output": 0.00236,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/qwen/qwen3-30b-a3b-instruct-2507-fp8": {
+    "input": 0.35,
+    "output": 1.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/qwen/qwen3-embedding-8b": {
+    "input": 0.12,
+    "output": 0.12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "evroc/qwen/qwen3-vl-30b-a3b-instruct": {
+    "input": 0.24,
+    "output": 0.94,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "exa-answer": {
+    "input": 2.5,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "exa-research": {
+    "input": 2.5,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "exa-research-pro": {
+    "input": 2.5,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fastgpt": {
+    "input": 7.5,
+    "output": 7.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fastrouter/anthropic/claude-opus-4.1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "fastrouter/anthropic/claude-sonnet-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "fastrouter/deepseek-ai/deepseek-r1-distill-llama-70b": {
+    "input": 0.03,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fastrouter/google/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.0375
+  },
+  "fastrouter/google/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.31
+  },
+  "fastrouter/moonshotai/kimi-k2": {
+    "input": 0.55,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fastrouter/openai/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "fastrouter/openai/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "fastrouter/openai/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "fastrouter/openai/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.005
+  },
+  "fastrouter/openai/gpt-oss-120b": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fastrouter/openai/gpt-oss-20b": {
+    "input": 0.05,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fastrouter/qwen/qwen3-coder": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fastrouter/x-ai/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 15,
+    "cacheRead": 0.75
+  },
+  "fastrouter/z-ai/glm-5": {
+    "input": 0.95,
+    "output": 3.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fireworks-ai/accounts/fireworks/models/deepseek-v3p1": {
+    "input": 0.56,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fireworks-ai/accounts/fireworks/models/deepseek-v3p2": {
+    "input": 0.56,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0.28
+  },
+  "fireworks-ai/accounts/fireworks/models/glm-4p5": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fireworks-ai/accounts/fireworks/models/glm-4p5-air": {
+    "input": 0.22,
+    "output": 0.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fireworks-ai/accounts/fireworks/models/glm-4p7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "fireworks-ai/accounts/fireworks/models/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "fireworks-ai/accounts/fireworks/models/gpt-oss-120b": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fireworks-ai/accounts/fireworks/models/gpt-oss-20b": {
+    "input": 0.05,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "fireworks-ai/accounts/fireworks/models/kimi-k2-instruct": {
     "input": 1,
     "output": 3,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "featherless/qwerky-72b": {
+  "fireworks-ai/accounts/fireworks/models/kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "fireworks-ai/accounts/fireworks/models/kimi-k2p5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "fireworks-ai/accounts/fireworks/models/minimax-m2p1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "fireworks-ai/accounts/fireworks/models/minimax-m2p5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo": {
     "input": 0,
     "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "firmware/claude-haiku-4-5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "firmware/claude-opus-4-5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "firmware/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "firmware/claude-sonnet-4-5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "firmware/claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "firmware/deepseek-v3-2": {
+    "input": 0.58,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0.28
+  },
+  "firmware/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "firmware/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.31
+  },
+  "firmware/gemini-3-1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "firmware/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "firmware/gemini-3-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "firmware/gpt-4o": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "firmware/gpt-5-3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "firmware/gpt-5-4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "firmware/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "firmware/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "firmware/gpt-oss-120b": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "firmware/gpt-oss-20b": {
+    "input": 0.07,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "firmware/grok-4-1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "firmware/grok-4-1-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "firmware/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "firmware/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "firmware/minimax-m2-5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "firmware/zai-glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "flux-dev": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "flux-schnell": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "flux.1-dev": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "flux.2-flex": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "flux.2-klein-4b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "flux.2-max": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "flux.2-pro": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "friendli/meta-llama/llama-3.1-8b-instruct": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "friendli/meta-llama/llama-3.3-70b-instruct": {
+    "input": 0.6,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "friendli/minimaxai/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "friendli/minimaxai/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "friendli/qwen/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "friendli/zai-org/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "frontier": {
+    "input": 5,
+    "output": 25,
     "cacheWrite": 0,
     "cacheRead": 0
   },
@@ -467,9 +7979,45 @@
     "cacheWrite": 0,
     "cacheRead": 0.025
   },
+  "gemini-2.0-flash-exp-image-generation": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "gemini-2.0-flash-lite": {
     "input": 0.075,
     "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-2.0-flash-lite-001": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-2.0-flash-thinking-exp-01-21": {
+    "input": 0.306,
+    "output": 1.003,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-2.0-flash-thinking-exp-1219": {
+    "input": 0.1003,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-2.0-pro-exp-02-05": {
+    "input": 1.989,
+    "output": 7.956,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-2.0-pro-reasoner": {
+    "input": 1.292,
+    "output": 4.998,
     "cacheWrite": 0,
     "cacheRead": 0
   },
@@ -509,11 +8057,35 @@
     "cacheWrite": 0,
     "cacheRead": 0.025
   },
+  "gemini-2.5-flash-lite-preview-09-2025-thinking": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-2.5-flash-nothink": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-2.5-flash-nothinking": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "gemini-2.5-flash-preview-04-17": {
     "input": 0.15,
     "output": 0.6,
     "cacheWrite": 0,
     "cacheRead": 0.0375
+  },
+  "gemini-2.5-flash-preview-04-17:thinking": {
+    "input": 0.15,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
   },
   "gemini-2.5-flash-preview-05-20": {
     "input": 0.15,
@@ -521,11 +8093,23 @@
     "cacheWrite": 0,
     "cacheRead": 0.0375
   },
+  "gemini-2.5-flash-preview-05-20:thinking": {
+    "input": 0.15,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "gemini-2.5-flash-preview-09-2025": {
     "input": 0.3,
     "output": 2.5,
     "cacheWrite": 0,
     "cacheRead": 0.075
+  },
+  "gemini-2.5-flash-preview-09-2025-thinking": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
   },
   "gemini-2.5-flash-preview-tts": {
     "input": 0.5,
@@ -538,6 +8122,24 @@
     "output": 10,
     "cacheWrite": 0,
     "cacheRead": 0.31
+  },
+  "gemini-2.5-pro-exp-03-25": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-2.5-pro-preview": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.125
+  },
+  "gemini-2.5-pro-preview-03-25": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
   },
   "gemini-2.5-pro-preview-05-06": {
     "input": 1.25,
@@ -563,15 +8165,93 @@
     "cacheWrite": 0,
     "cacheRead": 0.05
   },
+  "gemini-3-flash-preview-thinking": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-3-pro-image": {
+    "input": 2,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "gemini-3-pro-preview": {
     "input": 2,
     "output": 12,
     "cacheWrite": 0,
     "cacheRead": 0.2
   },
+  "gemini-3-pro-preview-search": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "gemini-3-pro-preview-thinking": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-3.1-flash-image-preview": {
+    "input": 0.25,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-3.1-flash-lite": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-3.1-flash-lite-preview": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 1,
+    "cacheRead": 0.025
+  },
+  "gemini-3.1-pro": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "gemini-3.1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "gemini-3.1-pro-preview-customtools": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "gemini-deep-research": {
+    "input": 1.6,
+    "output": 9.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "gemini-embedding-001": {
     "input": 0.15,
     "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-exp-1206": {
+    "input": 1.258,
+    "output": 4.998,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemini-flash-1.5": {
+    "input": 0.0748,
+    "output": 0.306,
     "cacheWrite": 0,
     "cacheRead": 0
   },
@@ -599,7 +8279,223 @@
     "cacheWrite": 0,
     "cacheRead": 0
   },
+  "gemini-pro-latest": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "gemma-2-27b-it": {
+    "input": 0.65,
+    "output": 0.65,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-2-27b-it-together": {
+    "input": 0.08,
+    "output": 0.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-2-2b-it": {
+    "input": 0.02,
+    "output": 0.06,
+    "cacheWrite": 0.025,
+    "cacheRead": 0.002
+  },
+  "gemma-2-9b-it": {
+    "input": 0.03,
+    "output": 0.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-2-9b-it-fast": {
+    "input": 0.03,
+    "output": 0.09,
+    "cacheWrite": 0.0375,
+    "cacheRead": 0.003
+  },
+  "gemma-3": {
+    "input": 0.15,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-12b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-12b-it:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-27b": {
+    "input": 0.27,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-27b-arliai-rpmax-v3": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-27b-big-tiger-v3": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-27b-cardprojector-v4": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-27b-glitter": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-27b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-27b-it-abliterated": {
+    "input": 0.42,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-27b-it-fast": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0.25,
+    "cacheRead": 0.02
+  },
+  "gemma-3-27b-it:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-27b-nidum-uncensored": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-4b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3-4b-it:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3n-e2b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3n-e2b-it:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3n-e4b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-3n-e4b-it:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-4-26b-a4b-it": {
+    "input": 0.13,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-4-31b-it": {
+    "input": 0.14,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gemma-sea-lion-v4-27b-it": {
+    "input": 0.35,
+    "output": 0.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "giga-potato": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "giga-potato-thinking": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-copilot/claude-haiku-4.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-copilot/claude-opus-4.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-copilot/claude-opus-4.6": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-copilot/claude-opus-41": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "github-copilot/claude-sonnet-4": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-copilot/claude-sonnet-4.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-copilot/claude-sonnet-4.6": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
@@ -618,6 +8514,12 @@
     "cacheRead": 0
   },
   "github-copilot/gemini-3-pro-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-copilot/gemini-3.1-pro-preview": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
@@ -683,6 +8585,516 @@
     "cacheWrite": 0,
     "cacheRead": 0
   },
+  "github-copilot/gpt-5.3-codex": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-copilot/gpt-5.4": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-copilot/gpt-5.4-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-copilot/grok-code-fast-1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/ai21-labs/ai21-jamba-1.5-large": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/ai21-labs/ai21-jamba-1.5-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/cohere/cohere-command-a": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/cohere/cohere-command-r": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/cohere/cohere-command-r-08-2024": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/cohere/cohere-command-r-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/cohere/cohere-command-r-plus-08-2024": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/core42/jais-30b-chat": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/deepseek/deepseek-r1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/deepseek/deepseek-r1-0528": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/deepseek/deepseek-v3-0324": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/meta/llama-3.2-11b-vision-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/meta/llama-3.2-90b-vision-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/meta/llama-3.3-70b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/meta/llama-4-maverick-17b-128e-instruct-fp8": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/meta/llama-4-scout-17b-16e-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/meta/meta-llama-3-70b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/meta/meta-llama-3-8b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/meta/meta-llama-3.1-405b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/meta/meta-llama-3.1-70b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/meta/meta-llama-3.1-8b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/mai-ds-r1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-3-medium-128k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-3-medium-4k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-3-mini-128k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-3-mini-4k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-3-small-128k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-3-small-8k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-3.5-mini-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-3.5-moe-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-3.5-vision-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-4": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-4-mini-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-4-mini-reasoning": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-4-multimodal-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/microsoft/phi-4-reasoning": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/mistral-ai/codestral-2501": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/mistral-ai/ministral-3b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/mistral-ai/mistral-large-2411": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/mistral-ai/mistral-medium-2505": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/mistral-ai/mistral-nemo": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/mistral-ai/mistral-small-2503": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/openai/gpt-4.1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/openai/gpt-4.1-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/openai/gpt-4.1-nano": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/openai/gpt-4o": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/openai/gpt-4o-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/openai/o1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/openai/o1-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/openai/o1-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/openai/o3": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/openai/o3-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/openai/o4-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/xai/grok-3": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "github-models/xai/grok-3-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-gpt-5-1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-gpt-5-2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-gpt-5-2-codex": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-gpt-5-3-codex": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-gpt-5-4": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-gpt-5-4-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-gpt-5-4-nano": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-gpt-5-codex": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-gpt-5-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-haiku-4-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-opus-4-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-opus-4-6": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-sonnet-4-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gitlab/duo-chat-sonnet-4-6": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4": {
+    "input": 14.994,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4-32b": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4-32b-0414-128k": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4-air": {
+    "input": 0.2006,
+    "output": 0.2006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4-air-0111": {
+    "input": 0.1394,
+    "output": 0.1394,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4-airx": {
+    "input": 2.006,
+    "output": 2.006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4-flash": {
+    "input": 0.1003,
+    "output": 0.1003,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4-long": {
+    "input": 0.2006,
+    "output": 0.2006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4-plus": {
+    "input": 7.497,
+    "output": 7.497,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4-plus-0111": {
+    "input": 9.996,
+    "output": 9.996,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.1v-thinking-flash": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.1v-thinking-flashx": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "glm-4.5": {
     "input": 0.6,
     "output": 2.2,
@@ -695,13 +9107,85 @@
     "cacheWrite": 0,
     "cacheRead": 0.03
   },
+  "glm-4.5-air-derestricted": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.5-air-derestricted-iceblink": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.5-air-derestricted-iceblink-reextract": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.5-air-derestricted-iceblink-v2": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.5-air-derestricted-iceblink-v2-reextract": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.5-air-derestricted-steam": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.5-air-derestricted-steam-reextract": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.5-air:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.5-airx": {
+    "input": 1.1,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.22
+  },
   "glm-4.5-flash": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
+  "glm-4.5-tee": {
+    "input": 0.35,
+    "output": 1.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.5-x": {
+    "input": 2.2,
+    "output": 8.9,
+    "cacheWrite": 0,
+    "cacheRead": 0.45
+  },
   "glm-4.5v": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.5v:thinking": {
     "input": 0.6,
     "output": 1.8,
     "cacheWrite": 0,
@@ -713,9 +9197,57 @@
     "cacheWrite": 0,
     "cacheRead": 0.11
   },
+  "glm-4.6-derestricted-v5": {
+    "input": 0.4,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.6-fp8": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.6-tee": {
+    "input": 0.4,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "glm-4.6:exacto": {
+    "input": 0.6,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "glm-4.6:thinking": {
+    "input": 0.4,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "glm-4.6v": {
     "input": 0.3,
     "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.6v-flash": {
+    "input": 0.02,
+    "output": 0.21,
+    "cacheWrite": 0,
+    "cacheRead": 0.0043
+  },
+  "glm-4.6v-flash-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.6v-flashx": {
+    "input": 0.04,
+    "output": 0.4,
     "cacheWrite": 0,
     "cacheRead": 0
   },
@@ -731,15 +9263,477 @@
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "google/gemini-2.0-flash-001": {
+  "glm-4.7-flash-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.7-flashx": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "glm-4.7-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.7-maas": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4.7-tee": {
+    "input": 0.4,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4p5": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4p5-air": {
+    "input": 0.22,
+    "output": 0.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-4p7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "glm-5-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-5-maas": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "glm-5-tee": {
+    "input": 0.95,
+    "output": 3.15,
+    "cacheWrite": 0,
+    "cacheRead": 0.475
+  },
+  "glm-5-turbo": {
+    "input": 1.2,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "glm-5.1": {
+    "input": 0.3,
+    "output": 2.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-5.1:thinking": {
+    "input": 0.3,
+    "output": 2.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-5:thinking": {
+    "input": 0.3,
+    "output": 2.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-5v-turbo": {
+    "input": 1.2,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "glm-image": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-z1-air": {
+    "input": 0.07,
+    "output": 0.07,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-z1-airx": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-z1-rumination-32b-0414": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm-zero-preview": {
+    "input": 1.802,
+    "output": 1.802,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm4.7": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "glm5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "global.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "global.anthropic.claude-opus-4-6-v1": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "global.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "global.anthropic.claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "goliath-120b": {
+    "input": 3.75,
+    "output": 7.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-gemma-3-27b-it": {
+    "input": 0.12,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-vertex-anthropic/claude-3-5-haiku@20241022": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "google-vertex-anthropic/claude-3-5-sonnet@20241022": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "google-vertex-anthropic/claude-3-7-sonnet@20250219": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "google-vertex-anthropic/claude-haiku-4-5@20251001": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "google-vertex-anthropic/claude-opus-4-1@20250805": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "google-vertex-anthropic/claude-opus-4-5@20251101": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "google-vertex-anthropic/claude-opus-4-6@default": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "google-vertex-anthropic/claude-opus-4@20250514": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "google-vertex-anthropic/claude-sonnet-4-5@20250929": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "google-vertex-anthropic/claude-sonnet-4-6@default": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "google-vertex-anthropic/claude-sonnet-4@20250514": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "google-vertex/deepseek-ai/deepseek-v3.1-maas": {
+    "input": 0.6,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-vertex/gemini-2.0-flash": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "google-vertex/gemini-2.0-flash-lite": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-vertex/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0.383,
+    "cacheRead": 0.075
+  },
+  "google-vertex/gemini-2.5-flash-lite": {
     "input": 0.1,
     "output": 0.4,
     "cacheWrite": 0,
     "cacheRead": 0.025
   },
-  "google/gemini-2.0-flash-exp:free": {
-    "input": 0,
+  "google-vertex/gemini-2.5-flash-lite-preview-06-17": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "google-vertex/gemini-2.5-flash-lite-preview-09-2025": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "google-vertex/gemini-2.5-flash-preview-04-17": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.0375
+  },
+  "google-vertex/gemini-2.5-flash-preview-05-20": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.0375
+  },
+  "google-vertex/gemini-2.5-flash-preview-09-2025": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0.383,
+    "cacheRead": 0.075
+  },
+  "google-vertex/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.31
+  },
+  "google-vertex/gemini-2.5-pro-preview-05-06": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.31
+  },
+  "google-vertex/gemini-2.5-pro-preview-06-05": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.31
+  },
+  "google-vertex/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "google-vertex/gemini-3-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "google-vertex/gemini-3.1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "google-vertex/gemini-3.1-pro-preview-customtools": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "google-vertex/gemini-embedding-001": {
+    "input": 0.15,
     "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-vertex/gemini-flash-latest": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0.383,
+    "cacheRead": 0.075
+  },
+  "google-vertex/gemini-flash-lite-latest": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "google-vertex/meta/llama-3.3-70b-instruct-maas": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-vertex/meta/llama-4-maverick-17b-128e-instruct-maas": {
+    "input": 0.35,
+    "output": 1.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-vertex/moonshotai/kimi-k2-thinking-maas": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-vertex/openai/gpt-oss-120b-maas": {
+    "input": 0.09,
+    "output": 0.36,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-vertex/openai/gpt-oss-20b-maas": {
+    "input": 0.07,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-vertex/qwen/qwen3-235b-a22b-instruct-2507-maas": {
+    "input": 0.22,
+    "output": 0.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-vertex/zai-org/glm-4.7-maas": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google-vertex/zai-org/glm-5-maas": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "google.gemma-3-12b-it": {
+    "input": 0.05,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google.gemma-3-27b-it": {
+    "input": 0.12,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google.gemma-3-4b-it": {
+    "input": 0.04,
+    "output": 0.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google/gemini-1.5-flash": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.01875
+  },
+  "google/gemini-1.5-flash-8b": {
+    "input": 0.0375,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "google/gemini-1.5-pro": {
+    "input": 1.25,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0.3125
+  },
+  "google/gemini-2.0-flash": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "google/gemini-2.0-flash-lite": {
+    "input": 0.075,
+    "output": 0.3,
     "cacheWrite": 0,
     "cacheRead": 0
   },
@@ -747,9 +9741,27 @@
     "input": 0.3,
     "output": 2.5,
     "cacheWrite": 0,
-    "cacheRead": 0.0375
+    "cacheRead": 0.075
+  },
+  "google/gemini-2.5-flash-image": {
+    "input": 0.3,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "google/gemini-2.5-flash-image-preview": {
+    "input": 0.3,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
   },
   "google/gemini-2.5-flash-lite": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "google/gemini-2.5-flash-lite-preview-06-17": {
     "input": 0.1,
     "output": 0.4,
     "cacheWrite": 0,
@@ -761,11 +9773,29 @@
     "cacheWrite": 0,
     "cacheRead": 0.025
   },
+  "google/gemini-2.5-flash-preview-04-17": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.0375
+  },
+  "google/gemini-2.5-flash-preview-05-20": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.0375
+  },
   "google/gemini-2.5-flash-preview-09-2025": {
     "input": 0.3,
     "output": 2.5,
     "cacheWrite": 0,
-    "cacheRead": 0.031
+    "cacheRead": 0.075
+  },
+  "google/gemini-2.5-flash-preview-tts": {
+    "input": 0.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
   },
   "google/gemini-2.5-pro": {
     "input": 1.25,
@@ -785,6 +9815,12 @@
     "cacheWrite": 0,
     "cacheRead": 0.31
   },
+  "google/gemini-2.5-pro-preview-tts": {
+    "input": 1,
+    "output": 20,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "google/gemini-3-flash-preview": {
     "input": 0.5,
     "output": 3,
@@ -795,63 +9831,87 @@
     "input": 2,
     "output": 12,
     "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "google/gemini-3.1-flash-image-preview": {
+    "input": 0.25,
+    "output": 60,
+    "cacheWrite": 0,
     "cacheRead": 0
   },
-  "google/gemma-2-9b-it": {
-    "input": 0.03,
-    "output": 0.09,
+  "google/gemini-3.1-flash-lite-preview": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 1,
+    "cacheRead": 0.025
+  },
+  "google/gemini-3.1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "google/gemini-3.1-pro-preview-customtools": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "google/gemini-embedding-001": {
+    "input": 0.15,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google/gemini-flash-latest": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "google/gemini-flash-lite-latest": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "google/gemini-live-2.5-flash": {
+    "input": 0.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "google/gemini-live-2.5-flash-preview-native-audio": {
+    "input": 0.5,
+    "output": 2,
     "cacheWrite": 0,
     "cacheRead": 0
   },
   "google/gemma-3-12b-it": {
-    "input": 0.03,
-    "output": 0.1,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "google/gemma-3-12b-it:free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
   "google/gemma-3-27b-it": {
-    "input": 0.04,
-    "output": 0.15,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "google/gemma-3-27b-it:free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
   "google/gemma-3-4b-it": {
-    "input": 0.01703,
-    "output": 0.06815,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "google/gemma-3-4b-it:free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "google/gemma-3n-e2b-it:free": {
+  "google/gemma-3n-e2b-it": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
   "google/gemma-3n-e4b-it": {
-    "input": 0.02,
-    "output": 0.04,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "google/gemma-3n-e4b-it:free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
@@ -861,6 +9921,36 @@
     "input": 0.5,
     "output": 1.5,
     "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "gpt-3.5-turbo-0125": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-3.5-turbo-0301": {
+    "input": 1.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-3.5-turbo-1106": {
+    "input": 1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-3.5-turbo-16k": {
+    "input": 3,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-3.5-turbo-raw": {
+    "input": 0.45,
+    "output": 1.4,
+    "cacheWrite": 0,
     "cacheRead": 0
   },
   "gpt-4": {
@@ -869,7 +9959,43 @@
     "cacheWrite": 0,
     "cacheRead": 0
   },
+  "gpt-4-0314": {
+    "input": 30,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-4-1106-preview": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-4-32k": {
+    "input": 60,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-4-classic": {
+    "input": 27,
+    "output": 54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-4-classic-0314": {
+    "input": 27,
+    "output": 54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "gpt-4-turbo": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-4-turbo-vision": {
     "input": 10,
     "output": 30,
     "cacheWrite": 0,
@@ -887,6 +10013,12 @@
     "cacheWrite": 0,
     "cacheRead": 0.1
   },
+  "gpt-4.1-mini-2025-04-14": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
   "gpt-4.1-nano": {
     "input": 0.1,
     "output": 0.4,
@@ -897,7 +10029,7 @@
     "input": 2.5,
     "output": 10,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 1.25
   },
   "gpt-4o-2024-05-13": {
     "input": 5,
@@ -917,23 +10049,65 @@
     "cacheWrite": 0,
     "cacheRead": 1.25
   },
+  "gpt-4o-audio-preview": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-4o-aug": {
+    "input": 2.2,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 1.1
+  },
   "gpt-4o-mini": {
     "input": 0.15,
     "output": 0.6,
     "cacheWrite": 0,
     "cacheRead": 0.08
   },
+  "gpt-4o-mini-2024-07-18": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-4o-mini-search": {
+    "input": 0.14,
+    "output": 0.54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-4o-search": {
+    "input": 2.2,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-4o:extended": {
+    "input": 6,
+    "output": 18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "gpt-5": {
     "input": 1.25,
     "output": 10,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 0.125
   },
-  "gpt-5-chat": {
-    "input": 1.25,
-    "output": 10,
+  "gpt-5-3-codex": {
+    "input": 1.75,
+    "output": 14,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 0.175
+  },
+  "gpt-5-4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
   },
   "gpt-5-chat-latest": {
     "input": 1.25,
@@ -945,29 +10119,35 @@
     "input": 1.25,
     "output": 10,
     "cacheWrite": 0,
-    "cacheRead": 0.13
+    "cacheRead": 0.125
   },
-  "gpt-5-image": {
-    "input": 5,
-    "output": 10,
+  "gpt-5-image-mini": {
+    "input": 2.5,
+    "output": 2,
     "cacheWrite": 0,
-    "cacheRead": 1.25
+    "cacheRead": 0
   },
   "gpt-5-mini": {
     "input": 0.25,
     "output": 2,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 0.025
   },
   "gpt-5-nano": {
     "input": 0.05,
     "output": 0.4,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 0.005
   },
   "gpt-5-pro": {
     "input": 15,
     "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-5-thinking": {
+    "input": 1.25,
+    "output": 10,
     "cacheWrite": 0,
     "cacheRead": 0
   },
@@ -977,11 +10157,11 @@
     "cacheWrite": 0,
     "cacheRead": 0.13
   },
-  "gpt-5.1-chat": {
+  "gpt-5.1-2025-11-13": {
     "input": 1.25,
     "output": 10,
     "cacheWrite": 0,
-    "cacheRead": 0.13
+    "cacheRead": 0
   },
   "gpt-5.1-chat-latest": {
     "input": 1.25,
@@ -993,7 +10173,7 @@
     "input": 1.25,
     "output": 10,
     "cacheWrite": 0,
-    "cacheRead": 0.13
+    "cacheRead": 0.125
   },
   "gpt-5.1-codex-max": {
     "input": 1.25,
@@ -1005,7 +10185,13 @@
     "input": 0.25,
     "output": 2,
     "cacheWrite": 0,
-    "cacheRead": 0.03
+    "cacheRead": 0.025
+  },
+  "gpt-5.1-thinking": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
   },
   "gpt-5.2": {
     "input": 1.75,
@@ -1025,17 +10211,389 @@
     "cacheWrite": 0,
     "cacheRead": 0.175
   },
+  "gpt-5.2-instant": {
+    "input": 1.6,
+    "output": 13,
+    "cacheWrite": 0,
+    "cacheRead": 0.16
+  },
   "gpt-5.2-pro": {
     "input": 21,
     "output": 168,
     "cacheWrite": 0,
     "cacheRead": 0
   },
+  "gpt-5.3-chat-latest": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
   "gpt-5.3-codex": {
     "input": 1.75,
     "output": 14,
     "cacheWrite": 0,
     "cacheRead": 0.175
+  },
+  "gpt-5.3-codex-spark": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "gpt-5.3-codex-xhigh": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-5.3-instant": {
+    "input": 1.6,
+    "output": 13,
+    "cacheWrite": 0,
+    "cacheRead": 0.16
+  },
+  "gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "gpt-5.4-mini": {
+    "input": 0.75,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "gpt-5.4-nano": {
+    "input": 0.2,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "gpt-5.4-pro": {
+    "input": 30,
+    "output": 180,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-audio": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-audio-mini": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-oss-120b-high-throughput": {
+    "input": 0.09,
+    "output": 0.36,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-oss-120b-maas": {
+    "input": 0.09,
+    "output": 0.36,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-oss-120b-tee": {
+    "input": 0.04,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-oss-120b:exacto": {
+    "input": 0.05,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-oss-120b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-oss-20b-maas": {
+    "input": 0.07,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "gpt-oss-20b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "granite-4.0-h-micro": {
+    "input": 0.017,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "grayline-qwen3-8b": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "grok-2": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "grok-2-1212": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "grok-2-latest": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "grok-2-vision": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "grok-2-vision-1212": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "grok-2-vision-latest": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "grok-3": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "grok-3-fast": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "grok-3-fast-beta": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "grok-3-fast-latest": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "grok-3-latest": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "grok-3-mini": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "grok-3-mini-fast": {
+    "input": 0.6,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "grok-3-mini-fast-beta": {
+    "input": 0.6,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "grok-3-mini-fast-latest": {
+    "input": 0.6,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "grok-3-mini-latest": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "grok-4-07-09": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "grok-4-1-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "grok-4-1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "grok-4-20-beta": {
+    "input": 2.5,
+    "output": 7.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "grok-4-20-beta-0309-non-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "grok-4-20-beta-0309-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "grok-4-20-multi-agent-beta": {
+    "input": 2.5,
+    "output": 7.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "grok-4-20-multi-agent-beta-0309": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "grok-4-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "grok-4-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "grok-4-fast:thinking": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "grok-4.1": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "grok-4.1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "grok-4.2-fast": {
+    "input": 3,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "grok-4.2-fast-non-reasoning": {
+    "input": 3,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "grok-4.20-0309-non-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "grok-4.20-0309-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "grok-4.20-multi-agent": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "grok-4.20-multi-agent-0309": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "grok-4.20-non-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "grok-4.20-non-reasoning-beta": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "grok-4.20-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "grok-4.20-reasoning-beta": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "grok-41-fast": {
+    "input": 0.25,
+    "output": 0.625,
+    "cacheWrite": 0,
+    "cacheRead": 0.0625
+  },
+  "grok-beta": {
+    "input": 5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 5
   },
   "grok-code": {
     "input": 0,
@@ -1044,106 +10602,6586 @@
     "cacheRead": 0
   },
   "grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "grok-code-fast-1:optimized:free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "kimi-k2": {
+  "grok-imagine-image": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "grok-imagine-image-pro": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "grok-vision-beta": {
+    "input": 5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 5
+  },
+  "groq-llama-4-maverick-17b-128e-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/allam-2-7b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/canopylabs/orpheus-arabic-saudi": {
+    "input": 40,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/canopylabs/orpheus-v1-english": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/deepseek-r1-distill-llama-70b": {
+    "input": 0.75,
+    "output": 0.99,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/gemma2-9b-it": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/groq/compound": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/groq/compound-mini": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/llama-3.1-8b-instant": {
+    "input": 0.05,
+    "output": 0.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/llama-3.3-70b-versatile": {
+    "input": 0.59,
+    "output": 0.79,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/llama-guard-3-8b": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/llama3-70b-8192": {
+    "input": 0.59,
+    "output": 0.79,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/llama3-8b-8192": {
+    "input": 0.05,
+    "output": 0.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/meta-llama/llama-4-maverick-17b-128e-instruct": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/meta-llama/llama-4-scout-17b-16e-instruct": {
+    "input": 0.11,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/meta-llama/llama-guard-4-12b": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/meta-llama/llama-prompt-guard-2-22m": {
+    "input": 0.03,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/meta-llama/llama-prompt-guard-2-86m": {
+    "input": 0.04,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/mistral-saba-24b": {
+    "input": 0.79,
+    "output": 0.79,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/moonshotai/kimi-k2-instruct": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/moonshotai/kimi-k2-instruct-0905": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/openai/gpt-oss-120b": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/openai/gpt-oss-20b": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/openai/gpt-oss-safeguard-20b": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.037
+  },
+  "groq/qwen-qwq-32b": {
+    "input": 0.29,
+    "output": 0.39,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/qwen/qwen3-32b": {
+    "input": 0.29,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/whisper-large-v3": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "groq/whisper-large-v3-turbo": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "healer-alpha": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/chatgpt-4o-latest": {
+    "input": 5,
+    "output": 20,
+    "cacheWrite": 0,
+    "cacheRead": 2.5
+  },
+  "helicone/claude-3-haiku-20240307": {
+    "input": 0.25,
+    "output": 1.25,
+    "cacheWrite": 0.3,
+    "cacheRead": 0.03
+  },
+  "helicone/claude-3.5-haiku": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "helicone/claude-3.5-sonnet-v2": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "helicone/claude-3.7-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "helicone/claude-4.5-haiku": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "helicone/claude-4.5-opus": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "helicone/claude-4.5-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "helicone/claude-haiku-4-5-20251001": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "helicone/claude-opus-4": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "helicone/claude-opus-4-1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "helicone/claude-opus-4-1-20250805": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "helicone/claude-sonnet-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "helicone/claude-sonnet-4-5-20250929": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "helicone/codex-mini-latest": {
+    "input": 1.5,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.375
+  },
+  "helicone/deepseek-r1-distill-llama-70b": {
+    "input": 0.03,
+    "output": 0.13,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/deepseek-reasoner": {
+    "input": 0.56,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0.07
+  },
+  "helicone/deepseek-tng-r1t2-chimera": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/deepseek-v3": {
+    "input": 0.56,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0.07
+  },
+  "helicone/deepseek-v3.1-terminus": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0.216
+  },
+  "helicone/deepseek-v3.2": {
+    "input": 0.27,
+    "output": 0.41,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/ernie-4.5-21b-a3b-thinking": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0.3,
+    "cacheRead": 0.075
+  },
+  "helicone/gemini-2.5-flash-lite": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0.1,
+    "cacheRead": 0.025
+  },
+  "helicone/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.3125
+  },
+  "helicone/gemini-3-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "helicone/gemma-3-12b-it": {
+    "input": 0.05,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/gemma2-9b-it": {
+    "input": 0.01,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/glm-4.6": {
+    "input": 0.45,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "helicone/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "helicone/gpt-4.1-mini-2025-04-14": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "helicone/gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "helicone/gpt-4o": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "helicone/gpt-4o-mini": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "helicone/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "helicone/gpt-5-chat-latest": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "helicone/gpt-5-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "helicone/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "helicone/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.005
+  },
+  "helicone/gpt-5-pro": {
+    "input": 15,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "helicone/gpt-5.1-chat-latest": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "helicone/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "helicone/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "helicone/gpt-oss-120b": {
+    "input": 0.04,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/gpt-oss-20b": {
+    "input": 0.05,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/grok-3": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "helicone/grok-3-mini": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "helicone/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "helicone/grok-4-1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "helicone/grok-4-1-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "helicone/grok-4-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "helicone/grok-4-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "helicone/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "helicone/hermes-2-pro-llama-3-8b": {
+    "input": 0.14,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/kimi-k2-0711": {
+    "input": 0.57,
+    "output": 2.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/kimi-k2-0905": {
+    "input": 0.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.4
+  },
+  "helicone/kimi-k2-thinking": {
+    "input": 0.48,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/llama-3.1-8b-instant": {
+    "input": 0.05,
+    "output": 0.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/llama-3.1-8b-instruct": {
+    "input": 0.02,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/llama-3.1-8b-instruct-turbo": {
+    "input": 0.02,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/llama-3.3-70b-instruct": {
+    "input": 0.13,
+    "output": 0.39,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/llama-3.3-70b-versatile": {
+    "input": 0.59,
+    "output": 0.79,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/llama-4-maverick": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/llama-4-scout": {
+    "input": 0.08,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/llama-guard-4": {
+    "input": 0.21,
+    "output": 0.21,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/llama-prompt-guard-2-22m": {
+    "input": 0.01,
+    "output": 0.01,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/llama-prompt-guard-2-86m": {
+    "input": 0.01,
+    "output": 0.01,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/mistral-large-2411": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/mistral-nemo": {
+    "input": 20,
+    "output": 40,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/mistral-small": {
+    "input": 75,
+    "output": 200,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/o1": {
+    "input": 15,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 7.5
+  },
+  "helicone/o1-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "helicone/o3": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "helicone/o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "helicone/o3-pro": {
+    "input": 20,
+    "output": 80,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.275
+  },
+  "helicone/qwen2.5-coder-7b-fast": {
+    "input": 0.03,
+    "output": 0.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/qwen3-235b-a22b-thinking": {
+    "input": 0.3,
+    "output": 2.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/qwen3-30b-a3b": {
+    "input": 0.08,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/qwen3-32b": {
+    "input": 0.29,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/qwen3-coder": {
+    "input": 0.22,
+    "output": 0.95,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/qwen3-next-80b-a3b-instruct": {
+    "input": 0.14,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/qwen3-vl-235b-a22b-instruct": {
+    "input": 0.3,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/sonar": {
+    "input": 1,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/sonar-deep-research": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/sonar-pro": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/sonar-reasoning": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "helicone/sonar-reasoning-pro": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hermes-2-pro-llama-3-8b": {
+    "input": 0.14,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hermes-3-llama-3.1-405b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hermes-4-14b": {
+    "input": 0.01,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hermes-4-405b-fp8-tee": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hermes-4-405b:thinking": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hermes-4-70b:thinking": {
+    "input": 0.2006,
+    "output": 0.3995,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hermes-4.3-36b": {
+    "input": 0.1,
+    "output": 0.39,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/deepseek-ai/deepseek-r1-0528": {
+    "input": 3,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/deepseek-ai/deepseek-v3.2": {
+    "input": 0.28,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/minimaxai/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/minimaxai/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "huggingface/moonshotai/kimi-k2-instruct": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/moonshotai/kimi-k2-instruct-0905": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/moonshotai/kimi-k2-thinking": {
     "input": 0.6,
     "output": 2.5,
     "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "huggingface/moonshotai/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "huggingface/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.3,
+    "output": 3,
+    "cacheWrite": 0,
     "cacheRead": 0
   },
-  "kwaipilot/kat-coder-pro:free": {
+  "huggingface/qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": 2,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/qwen/qwen3-coder-next": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/qwen/qwen3-embedding-4b": {
+    "input": 0.01,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/qwen/qwen3-embedding-8b": {
+    "input": 0.01,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/qwen/qwen3-next-80b-a3b-instruct": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/qwen/qwen3-next-80b-a3b-thinking": {
+    "input": 0.3,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/qwen/qwen3.5-397b-a17b": {
+    "input": 0.6,
+    "output": 3.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/xiaomimimo/mimo-v2-flash": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "huggingface/zai-org/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "huggingface/zai-org/glm-4.7-flash": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "liquid/lfm-2.5-1.2b-instruct:free": {
+  "huggingface/zai-org/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "hunter-alpha": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "liquid/lfm-2.5-1.2b-thinking:free": {
+  "hunyuan-2.0-instruct": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "llama-3.1": {
-    "input": 0.06,
-    "output": 0.06,
+  "hunyuan-2.0-thinking": {
+    "input": 0,
+    "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "llama-3.2": {
+  "hunyuan-a13b-instruct": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hunyuan-mt-7b": {
+    "input": 10,
+    "output": 20,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hunyuan-t1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hunyuan-t1-latest": {
+    "input": 0.17,
+    "output": 0.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hunyuan-turbos": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "hunyuan-turbos-20250226": {
+    "input": 0.187,
+    "output": 0.374,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/deepseek-r1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/deepseek-v3": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/deepseek-v3.2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/glm-4.6": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/kimi-k2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/kimi-k2-0905": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/qwen3-235b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/qwen3-235b-a22b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/qwen3-235b-a22b-thinking-2507": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/qwen3-32b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/qwen3-coder-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/qwen3-max": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/qwen3-max-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "iflowcn/qwen3-vl-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "inception/mercury": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 1,
+    "cacheRead": 0.25
+  },
+  "inception/mercury-2": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "inception/mercury-coder": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 1,
+    "cacheRead": 0.25
+  },
+  "inception/mercury-edit": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "indictrans2-en-indic-1b": {
+    "input": 0.34,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "inference/google/gemma-3": {
+    "input": 0.15,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "inference/meta/llama-3.1-8b-instruct": {
+    "input": 0.025,
+    "output": 0.025,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "inference/meta/llama-3.2-11b-vision-instruct": {
     "input": 0.055,
     "output": 0.055,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "llama-3.3": {
+  "inference/meta/llama-3.2-1b-instruct": {
+    "input": 0.01,
+    "output": 0.01,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "inference/meta/llama-3.2-3b-instruct": {
+    "input": 0.02,
+    "output": 0.02,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "inference/mistral/mistral-nemo-12b-instruct": {
+    "input": 0.038,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "inference/osmosis/osmosis-structure-0.6b": {
+    "input": 0.1,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "inference/qwen/qwen-2.5-7b-vision-instruct": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "inference/qwen/qwen3-embedding-4b": {
+    "input": 0.01,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "internvl3-78b-tee": {
+    "input": 0.1,
+    "output": 0.39,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "io-net/deepseek-ai/deepseek-r1-0528": {
+    "input": 2,
+    "output": 8.75,
+    "cacheWrite": 4,
+    "cacheRead": 1
+  },
+  "io-net/intel/qwen3-coder-480b-a35b-instruct-int4-mixed-ar": {
+    "input": 0.22,
+    "output": 0.95,
+    "cacheWrite": 0.44,
+    "cacheRead": 0.11
+  },
+  "io-net/meta-llama/llama-3.2-90b-vision-instruct": {
+    "input": 0.35,
+    "output": 0.4,
+    "cacheWrite": 0.7,
+    "cacheRead": 0.175
+  },
+  "io-net/meta-llama/llama-3.3-70b-instruct": {
+    "input": 0.13,
+    "output": 0.38,
+    "cacheWrite": 0.26,
+    "cacheRead": 0.065
+  },
+  "io-net/meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0.3,
+    "cacheRead": 0.075
+  },
+  "io-net/mistralai/devstral-small-2505": {
+    "input": 0.05,
+    "output": 0.22,
+    "cacheWrite": 0.1,
+    "cacheRead": 0.025
+  },
+  "io-net/mistralai/magistral-small-2506": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 1,
+    "cacheRead": 0.25
+  },
+  "io-net/mistralai/mistral-large-instruct-2411": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 4,
+    "cacheRead": 1
+  },
+  "io-net/mistralai/mistral-nemo-instruct-2407": {
+    "input": 0.02,
+    "output": 0.04,
+    "cacheWrite": 0.04,
+    "cacheRead": 0.01
+  },
+  "io-net/moonshotai/kimi-k2-instruct-0905": {
+    "input": 0.39,
+    "output": 1.9,
+    "cacheWrite": 0.78,
+    "cacheRead": 0.195
+  },
+  "io-net/moonshotai/kimi-k2-thinking": {
+    "input": 0.55,
+    "output": 2.25,
+    "cacheWrite": 1.1,
+    "cacheRead": 0.275
+  },
+  "io-net/openai/gpt-oss-120b": {
+    "input": 0.04,
+    "output": 0.4,
+    "cacheWrite": 0.08,
+    "cacheRead": 0.02
+  },
+  "io-net/openai/gpt-oss-20b": {
+    "input": 0.03,
+    "output": 0.14,
+    "cacheWrite": 0.06,
+    "cacheRead": 0.015
+  },
+  "io-net/qwen/qwen2.5-vl-32b-instruct": {
+    "input": 0.05,
+    "output": 0.22,
+    "cacheWrite": 0.1,
+    "cacheRead": 0.025
+  },
+  "io-net/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.11,
+    "output": 0.6,
+    "cacheWrite": 0.22,
+    "cacheRead": 0.055
+  },
+  "io-net/qwen/qwen3-next-80b-a3b-instruct": {
+    "input": 0.1,
+    "output": 0.8,
+    "cacheWrite": 0.2,
+    "cacheRead": 0.05
+  },
+  "io-net/zai-org/glm-4.6": {
+    "input": 0.4,
+    "output": 1.75,
+    "cacheWrite": 0.8,
+    "cacheRead": 0.2
+  },
+  "jais-30b-chat": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jamba-large": {
+    "input": 1.989,
+    "output": 7.99,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jamba-large-1.6": {
+    "input": 1.989,
+    "output": 7.99,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jamba-mini": {
+    "input": 0.1989,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jamba-mini-1.6": {
+    "input": 0.1989,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jamba-mini-1.7": {
+    "input": 0.1989,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/baidu/ernie-4.5-300b-a47b-paddle": {
+    "input": 0.28,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/baidu/ernie-4.5-vl-424b-a47b": {
+    "input": 0.42,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/claude-haiku-4-5-20251001": {
+    "input": 0.9,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/claude-opus-4-1-20250805": {
+    "input": 13.5,
+    "output": 67.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/claude-opus-4-20250514": {
+    "input": 13.5,
+    "output": 67.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/claude-opus-4-5-20251101": {
+    "input": 4.5,
+    "output": 22.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/claude-sonnet-4-20250514": {
+    "input": 2.7,
+    "output": 13.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/claude-sonnet-4-5-20250929": {
+    "input": 2.7,
+    "output": 13.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/deepseek/deepseek-r1-0528": {
+    "input": 0.7,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/deepseek/deepseek-v3-0324": {
+    "input": 0.28,
+    "output": 1.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/deepseek/deepseek-v3.1": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gemini-2.5-flash": {
+    "input": 0.27,
+    "output": 2.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gemini-2.5-flash-lite": {
+    "input": 0.09,
+    "output": 0.36,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gemini-2.5-flash-lite-preview-06-17": {
+    "input": 0.09,
+    "output": 0.36,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gemini-2.5-flash-lite-preview-09-2025": {
+    "input": 0.09,
+    "output": 0.36,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gemini-2.5-flash-preview-05-20": {
+    "input": 0.135,
+    "output": 3.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gemini-2.5-pro": {
+    "input": 1.125,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gemini-2.5-pro-preview-06-05": {
+    "input": 1.125,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gemini-3-pro-preview": {
+    "input": 1.8,
+    "output": 10.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5-chat-latest": {
+    "input": 1.125,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5-codex": {
+    "input": 1.125,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5-mini": {
+    "input": 0.225,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5-nano": {
+    "input": 0.045,
+    "output": 0.36,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5-pro": {
+    "input": 13.5,
+    "output": 108,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5.1": {
+    "input": 1.125,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5.1-codex": {
+    "input": 1.125,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5.1-codex-max": {
+    "input": 1.125,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5.1-codex-mini": {
+    "input": 0.225,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5.2": {
+    "input": 1.575,
+    "output": 12.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/gpt-5.2-pro": {
+    "input": 18.9,
+    "output": 151.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/grok-4-0709": {
+    "input": 2.7,
+    "output": 13.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/grok-4-1-fast-non-reasoning": {
+    "input": 0.18,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/grok-4-1-fast-reasoning": {
+    "input": 0.18,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/grok-4-fast-non-reasoning": {
+    "input": 0.18,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/grok-4-fast-reasoning": {
+    "input": 0.18,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/grok-code-fast-1": {
+    "input": 0.18,
+    "output": 1.35,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/minimax/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/minimaxai/minimax-m1-80k": {
+    "input": 0.55,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/moonshotai/kimi-k2-0905": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/moonshotai/kimi-k2-instruct": {
+    "input": 0.57,
+    "output": 2.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/moonshotai/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/o3": {
+    "input": 10,
+    "output": 40,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/qwen/qwen3-235b-a22b-fp8": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/qwen/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.15,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.3,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/qwen/qwen3-30b-a3b-fp8": {
+    "input": 0.09,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/qwen/qwen3-32b-fp8": {
+    "input": 0.1,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.29,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/qwen/qwen3-coder-next": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/qwen/qwen3-next-80b-a3b-instruct": {
+    "input": 0.15,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/qwen/qwen3-next-80b-a3b-thinking": {
+    "input": 0.15,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/xiaomimimo/mimo-v2-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/zai-org/glm-4.5": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/zai-org/glm-4.5v": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/zai-org/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "jiekou/zai-org/glm-4.7-flash": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "k2-think": {
+    "input": 0.17,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "k2p5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kat-coder": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kat-coder-air-v1": {
+    "input": 0.1,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kat-coder-exp-72b-1010": {
+    "input": 0.1,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kat-coder-pro-v1-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kat-coder-pro-v2": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "kat-dev": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/ai21/jamba-large-1.7": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/aion-labs/aion-1.0": {
+    "input": 4,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/aion-labs/aion-1.0-mini": {
+    "input": 0.7,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/aion-labs/aion-2.0": {
+    "input": 0.8,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/aion-labs/aion-rp-llama-3.1-8b": {
+    "input": 0.8,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/alfredpros/codellama-7b-instruct-solidity": {
+    "input": 0.8,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/alibaba/tongyi-deepresearch-30b-a3b": {
+    "input": 0.09,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/allenai/molmo-2-8b": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/allenai/olmo-2-0325-32b-instruct": {
+    "input": 0.05,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/allenai/olmo-3-32b-think": {
+    "input": 0.15,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/allenai/olmo-3-7b-instruct": {
+    "input": 0.1,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/allenai/olmo-3-7b-think": {
+    "input": 0.12,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/allenai/olmo-3.1-32b-instruct": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/allenai/olmo-3.1-32b-think": {
+    "input": 0.15,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/alpindale/goliath-120b": {
+    "input": 3.75,
+    "output": 7.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/amazon/nova-2-lite-v1": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/amazon/nova-lite-v1": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/amazon/nova-micro-v1": {
+    "input": 0.035,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/amazon/nova-premier-v1": {
+    "input": 2.5,
+    "output": 12.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/amazon/nova-pro-v1": {
+    "input": 0.8,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/anthracite-org/magnum-v4-72b": {
+    "input": 3,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/anthropic/claude-3-haiku": {
+    "input": 0.25,
+    "output": 1.25,
+    "cacheWrite": 0.3,
+    "cacheRead": 0.03
+  },
+  "kilo/anthropic/claude-3.5-haiku": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "kilo/anthropic/claude-3.5-sonnet": {
+    "input": 6,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/anthropic/claude-3.7-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "kilo/anthropic/claude-3.7-sonnet:thinking": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "kilo/anthropic/claude-haiku-4.5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "kilo/anthropic/claude-opus-4": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "kilo/anthropic/claude-opus-4.1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "kilo/anthropic/claude-opus-4.5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "kilo/anthropic/claude-opus-4.6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "kilo/anthropic/claude-sonnet-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "kilo/anthropic/claude-sonnet-4.5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "kilo/anthropic/claude-sonnet-4.6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/arcee-ai/coder-large": {
+    "input": 0.5,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/arcee-ai/maestro-reasoning": {
+    "input": 0.9,
+    "output": 3.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/arcee-ai/spotlight": {
+    "input": 0.18,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/arcee-ai/trinity-large-preview:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/arcee-ai/trinity-mini": {
+    "input": 0.045,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/arcee-ai/virtuoso-large": {
+    "input": 0.75,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/baidu/ernie-4.5-21b-a3b": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/baidu/ernie-4.5-21b-a3b-thinking": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/baidu/ernie-4.5-300b-a47b": {
+    "input": 0.28,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/baidu/ernie-4.5-vl-28b-a3b": {
+    "input": 0.14,
+    "output": 0.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/baidu/ernie-4.5-vl-424b-a47b": {
+    "input": 0.42,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/bytedance-seed/seed-1.6": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/bytedance-seed/seed-1.6-flash": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/bytedance-seed/seed-2.0-lite": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/bytedance-seed/seed-2.0-mini": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/bytedance/ui-tars-1.5-7b": {
+    "input": 0.1,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/cohere/command-a": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/cohere/command-r-08-2024": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/cohere/command-r-plus-08-2024": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/cohere/command-r7b-12-2024": {
+    "input": 0.0375,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/corethink:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/deepcogito/cogito-v2.1-671b": {
+    "input": 1.25,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/deepseek/deepseek-chat": {
+    "input": 0.32,
+    "output": 0.89,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "kilo/deepseek/deepseek-chat-v3-0324": {
+    "input": 0.2,
+    "output": 0.77,
+    "cacheWrite": 0,
+    "cacheRead": 0.095
+  },
+  "kilo/deepseek/deepseek-chat-v3.1": {
+    "input": 0.15,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/deepseek/deepseek-r1": {
+    "input": 0.7,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/deepseek/deepseek-r1-0528": {
+    "input": 0.45,
+    "output": 2.15,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "kilo/deepseek/deepseek-r1-distill-llama-70b": {
+    "input": 0.7,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.015
+  },
+  "kilo/deepseek/deepseek-r1-distill-qwen-32b": {
+    "input": 0.29,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/deepseek/deepseek-v3.1-terminus": {
+    "input": 0.21,
+    "output": 0.79,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "kilo/deepseek/deepseek-v3.2": {
+    "input": 0.26,
+    "output": 0.38,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "kilo/deepseek/deepseek-v3.2-exp": {
+    "input": 0.27,
+    "output": 0.41,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/deepseek/deepseek-v3.2-speciale": {
+    "input": 0.4,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.135
+  },
+  "kilo/eleutherai/llemma_7b": {
+    "input": 0.8,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/essentialai/rnj-1-instruct": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/giga-potato": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/giga-potato-thinking": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/google/gemini-2.0-flash-001": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0.083333,
+    "cacheRead": 0.025
+  },
+  "kilo/google/gemini-2.0-flash-lite-001": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/google/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0.083333,
+    "cacheRead": 0.03
+  },
+  "kilo/google/gemini-2.5-flash-image": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/google/gemini-2.5-flash-lite": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0.083333,
+    "cacheRead": 0.01
+  },
+  "kilo/google/gemini-2.5-flash-lite-preview-09-2025": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0.083333,
+    "cacheRead": 0.01
+  },
+  "kilo/google/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.125
+  },
+  "kilo/google/gemini-2.5-pro-preview": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.125
+  },
+  "kilo/google/gemini-2.5-pro-preview-05-06": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.125
+  },
+  "kilo/google/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0.083333,
+    "cacheRead": 0.05
+  },
+  "kilo/google/gemini-3-pro-image-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/google/gemini-3-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.2
+  },
+  "kilo/google/gemini-3.1-flash-image-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/google/gemini-3.1-flash-lite-preview": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/google/gemini-3.1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/google/gemini-3.1-pro-preview-customtools": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/google/gemma-2-27b-it": {
+    "input": 0.65,
+    "output": 0.65,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/google/gemma-2-9b-it": {
+    "input": 0.03,
+    "output": 0.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/google/gemma-3-12b-it": {
+    "input": 0.04,
+    "output": 0.13,
+    "cacheWrite": 0,
+    "cacheRead": 0.015
+  },
+  "kilo/google/gemma-3-27b-it": {
+    "input": 0.03,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "kilo/google/gemma-3-4b-it": {
+    "input": 0.04,
+    "output": 0.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/google/gemma-3n-e4b-it": {
+    "input": 0.02,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/gryphe/mythomax-l2-13b": {
     "input": 0.06,
     "output": 0.06,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "meta-llama/llama-3.1-405b-instruct:free": {
+  "kilo/ibm-granite/granite-4.0-h-micro": {
+    "input": 0.017,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/inception/mercury": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/inception/mercury-2": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "kilo/inception/mercury-coder": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/inflection/inflection-3-pi": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/inflection/inflection-3-productivity": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/kilo-auto/balanced": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/kilo-auto/free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "meta-llama/llama-3.2-11b-vision-instruct": {
+  "kilo/kilo-auto/frontier": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/kilo-auto/small": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/kilo/auto": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/kilo/auto-free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "meta-llama/llama-3.2-3b-instruct:free": {
-    "input": 0,
-    "output": 0,
+  "kilo/kilo/auto-small": {
+    "input": 0.05,
+    "output": 0.4,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "meta-llama/llama-3.3-70b-instruct:free": {
-    "input": 0,
-    "output": 0,
+  "kilo/kwaipilot/kat-coder-pro": {
+    "input": 0.207,
+    "output": 0.828,
+    "cacheWrite": 0,
+    "cacheRead": 0.0414
+  },
+  "kilo/liquid/lfm-2-24b-a2b": {
+    "input": 0.03,
+    "output": 0.12,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "meta-llama/llama-4-scout:free": {
-    "input": 0,
-    "output": 0,
+  "kilo/liquid/lfm-2.2-6b": {
+    "input": 0.01,
+    "output": 0.02,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "microsoft/mai-ds-r1:free": {
-    "input": 0,
-    "output": 0,
+  "kilo/liquid/lfm2-8b-a1b": {
+    "input": 0.01,
+    "output": 0.02,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "minimax/minimax-01": {
+  "kilo/mancer/weaver": {
+    "input": 0.75,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meituan/longcat-flash-chat": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "kilo/meta-llama/llama-3-70b-instruct": {
+    "input": 0.51,
+    "output": 0.74,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-3-8b-instruct": {
+    "input": 0.03,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-3.1-405b": {
+    "input": 4,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-3.1-405b-instruct": {
+    "input": 4,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-3.1-70b-instruct": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-3.1-8b-instruct": {
+    "input": 0.02,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-3.2-11b-vision-instruct": {
+    "input": 0.049,
+    "output": 0.049,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-3.2-1b-instruct": {
+    "input": 0.027,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-3.2-3b-instruct": {
+    "input": 0.051,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-3.3-70b-instruct": {
+    "input": 0.1,
+    "output": 0.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-4-maverick": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-4-scout": {
+    "input": 0.08,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-guard-3-8b": {
+    "input": 0.02,
+    "output": 0.06,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/meta-llama/llama-guard-4-12b": {
+    "input": 0.18,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/microsoft/phi-4": {
+    "input": 0.06,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/microsoft/wizardlm-2-8x22b": {
+    "input": 0.62,
+    "output": 0.62,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/minimax/minimax-01": {
     "input": 0.2,
     "output": 1.1,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "minimax/minimax-m1": {
+  "kilo/minimax/minimax-m1": {
     "input": 0.4,
     "output": 2.2,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "minimax/minimax-m2": {
-    "input": 0.28,
+  "kilo/minimax/minimax-m2": {
+    "input": 0.255,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "kilo/minimax/minimax-m2-her": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/minimax/minimax-m2.1": {
+    "input": 0.27,
+    "output": 0.95,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "kilo/minimax/minimax-m2.5": {
+    "input": 0.25,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.029
+  },
+  "kilo/minimax/minimax-m2.5:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/codestral-2508": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/devstral-2512": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "kilo/mistralai/devstral-medium": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/devstral-small": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/ministral-14b-2512": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/ministral-3b-2512": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/ministral-8b-2512": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mistral-7b-instruct-v0.1": {
+    "input": 0.11,
+    "output": 0.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mistral-large": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mistral-large-2407": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mistral-large-2411": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mistral-large-2512": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mistral-medium-3": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mistral-medium-3.1": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mistral-nemo": {
+    "input": 0.02,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mistral-saba": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mistral-small-24b-instruct-2501": {
+    "input": 0.05,
+    "output": 0.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mistral-small-3.1-24b-instruct": {
+    "input": 0.35,
+    "output": 0.56,
+    "cacheWrite": 0,
+    "cacheRead": 0.015
+  },
+  "kilo/mistralai/mistral-small-3.2-24b-instruct": {
+    "input": 0.06,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "kilo/mistralai/mistral-small-creative": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mixtral-8x22b-instruct": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/mixtral-8x7b-instruct": {
+    "input": 0.54,
+    "output": 0.54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/pixtral-large-2411": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/mistralai/voxtral-small-24b-2507": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/moonshotai/kimi-k2": {
+    "input": 0.55,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/moonshotai/kimi-k2-0905": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "kilo/moonshotai/kimi-k2-thinking": {
+    "input": 0.47,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "kilo/moonshotai/kimi-k2.5": {
+    "input": 0.45,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/morph-warp-grep-v2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/morph/morph-v3-fast": {
+    "input": 0.8,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/morph/morph-v3-large": {
+    "input": 0.9,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/nex-agi/deepseek-v3.1-nex-n1": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/nousresearch/hermes-2-pro-llama-3-8b": {
+    "input": 0.14,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/nousresearch/hermes-3-llama-3.1-405b": {
+    "input": 1,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/nousresearch/hermes-3-llama-3.1-70b": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/nousresearch/hermes-4-405b": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/nousresearch/hermes-4-70b": {
+    "input": 0.13,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.055
+  },
+  "kilo/nvidia/llama-3.1-nemotron-70b-instruct": {
+    "input": 1.2,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/nvidia/llama-3.3-nemotron-super-49b-v1.5": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/nvidia/nemotron-3-nano-30b-a3b": {
+    "input": 0.05,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/nvidia/nemotron-3-super-120b-a12b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/nvidia/nemotron-nano-12b-v2-vl": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/nvidia/nemotron-nano-9b-v2": {
+    "input": 0.04,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-3.5-turbo": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-3.5-turbo-0613": {
+    "input": 1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-3.5-turbo-16k": {
+    "input": 3,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-3.5-turbo-instruct": {
+    "input": 1.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-4": {
+    "input": 30,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-4-0314": {
+    "input": 30,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-4-1106-preview": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-4-turbo": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-4-turbo-preview": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "kilo/openai/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "kilo/openai/gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "kilo/openai/gpt-4o": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "kilo/openai/gpt-4o-2024-05-13": {
+    "input": 5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-4o-2024-08-06": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "kilo/openai/gpt-4o-2024-11-20": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "kilo/openai/gpt-4o-audio-preview": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-4o-mini": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "kilo/openai/gpt-4o-mini-2024-07-18": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-4o-mini-search-preview": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-4o-search-preview": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-4o:extended": {
+    "input": 6,
+    "output": 18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "kilo/openai/gpt-5-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "kilo/openai/gpt-5-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "kilo/openai/gpt-5-image": {
+    "input": 10,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-5-image-mini": {
+    "input": 2.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "kilo/openai/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.005
+  },
+  "kilo/openai/gpt-5-pro": {
+    "input": 15,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "kilo/openai/gpt-5.1-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "kilo/openai/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "kilo/openai/gpt-5.1-codex-max": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "kilo/openai/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "kilo/openai/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "kilo/openai/gpt-5.2-chat": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "kilo/openai/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "kilo/openai/gpt-5.2-pro": {
+    "input": 21,
+    "output": 168,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-5.3-chat": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-5.4-pro": {
+    "input": 30,
+    "output": 180,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-audio": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-audio-mini": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-oss-120b": {
+    "input": 0.039,
+    "output": 0.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-oss-20b": {
+    "input": 0.03,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/gpt-oss-safeguard-20b": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.037
+  },
+  "kilo/openai/o1": {
+    "input": 15,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 7.5
+  },
+  "kilo/openai/o1-pro": {
+    "input": 150,
+    "output": 600,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/o3": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "kilo/openai/o3-deep-research": {
+    "input": 10,
+    "output": 40,
+    "cacheWrite": 0,
+    "cacheRead": 2.5
+  },
+  "kilo/openai/o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "kilo/openai/o3-mini-high": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "kilo/openai/o3-pro": {
+    "input": 20,
+    "output": 80,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openai/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.275
+  },
+  "kilo/openai/o4-mini-deep-research": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "kilo/openai/o4-mini-high": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openrouter/auto": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openrouter/bodybuilder": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openrouter/free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openrouter/healer-alpha": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/openrouter/hunter-alpha": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/perplexity/sonar": {
+    "input": 1,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/perplexity/sonar-deep-research": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/perplexity/sonar-pro": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/perplexity/sonar-pro-search": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/perplexity/sonar-reasoning-pro": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/prime-intellect/intellect-3": {
+    "input": 0.2,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen-2.5-72b-instruct": {
+    "input": 0.12,
+    "output": 0.39,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen-2.5-7b-instruct": {
+    "input": 0.04,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen-2.5-coder-32b-instruct": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.015
+  },
+  "kilo/qwen/qwen-2.5-vl-7b-instruct": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen-max": {
+    "input": 1.04,
+    "output": 4.16,
+    "cacheWrite": 0,
+    "cacheRead": 0.32
+  },
+  "kilo/qwen/qwen-plus": {
+    "input": 0.4,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "kilo/qwen/qwen-plus-2025-07-28": {
+    "input": 0.26,
+    "output": 0.78,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen-plus-2025-07-28:thinking": {
+    "input": 0.26,
+    "output": 0.78,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen-turbo": {
+    "input": 0.0325,
+    "output": 0.13,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "kilo/qwen/qwen-vl-max": {
+    "input": 0.8,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen-vl-plus": {
+    "input": 0.1365,
+    "output": 0.4095,
+    "cacheWrite": 0,
+    "cacheRead": 0.042
+  },
+  "kilo/qwen/qwen2.5-coder-7b-instruct": {
+    "input": 0.03,
+    "output": 0.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen2.5-vl-32b-instruct": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "kilo/qwen/qwen2.5-vl-72b-instruct": {
+    "input": 0.8,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "kilo/qwen/qwen3-14b": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "kilo/qwen/qwen3-235b-a22b": {
+    "input": 0.455,
+    "output": 1.82,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "kilo/qwen/qwen3-235b-a22b-2507": {
+    "input": 0.071,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.11,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-30b-a3b": {
+    "input": 0.08,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "kilo/qwen/qwen3-30b-a3b-instruct-2507": {
+    "input": 0.09,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "kilo/qwen/qwen3-30b-a3b-thinking-2507": {
+    "input": 0.051,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-32b": {
+    "input": 0.08,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "kilo/qwen/qwen3-8b": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "kilo/qwen/qwen3-coder": {
+    "input": 0.22,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0.022
+  },
+  "kilo/qwen/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.07,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-coder-flash": {
+    "input": 0.195,
+    "output": 0.975,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "kilo/qwen/qwen3-coder-next": {
+    "input": 0.12,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.035
+  },
+  "kilo/qwen/qwen3-coder-plus": {
+    "input": 0.65,
+    "output": 3.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "kilo/qwen/qwen3-max": {
+    "input": 1.2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "kilo/qwen/qwen3-max-thinking": {
+    "input": 0.78,
+    "output": 3.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-next-80b-a3b-instruct": {
+    "input": 0.09,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-next-80b-a3b-thinking": {
+    "input": 0.0975,
+    "output": 0.78,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-vl-235b-a22b-instruct": {
+    "input": 0.2,
+    "output": 0.88,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "kilo/qwen/qwen3-vl-235b-a22b-thinking": {
+    "input": 0.26,
+    "output": 2.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-vl-30b-a3b-instruct": {
+    "input": 0.13,
+    "output": 0.52,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-vl-30b-a3b-thinking": {
+    "input": 0.13,
+    "output": 1.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-vl-32b-instruct": {
+    "input": 0.104,
+    "output": 0.416,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-vl-8b-instruct": {
+    "input": 0.08,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3-vl-8b-thinking": {
+    "input": 0.117,
+    "output": 1.365,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3.5-122b-a10b": {
+    "input": 0.26,
+    "output": 2.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3.5-27b": {
+    "input": 0.195,
+    "output": 1.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3.5-35b-a3b": {
+    "input": 0.1625,
+    "output": 1.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3.5-397b-a17b": {
+    "input": 0.39,
+    "output": 2.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3.5-9b": {
+    "input": 0.05,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3.5-flash-02-23": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwen3.5-plus-02-15": {
+    "input": 0.26,
+    "output": 1.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/qwen/qwq-32b": {
+    "input": 0.15,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/relace/relace-apply-3": {
+    "input": 0.85,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/relace/relace-search": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/sao10k/l3-euryale-70b": {
+    "input": 1.48,
+    "output": 1.48,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/sao10k/l3-lunaris-8b": {
+    "input": 0.04,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/sao10k/l3.1-70b-hanami-x1": {
+    "input": 3,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/sao10k/l3.1-euryale-70b": {
+    "input": 0.85,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/sao10k/l3.3-euryale-70b": {
+    "input": 0.65,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/stepfun/step-3.5-flash": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "kilo/stepfun/step-3.5-flash:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/switchpoint/router": {
+    "input": 0.85,
+    "output": 3.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/tencent/hunyuan-a13b-instruct": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/thedrummer/cydonia-24b-v4.1": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/thedrummer/rocinante-12b": {
+    "input": 0.17,
+    "output": 0.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/thedrummer/skyfall-36b-v2": {
+    "input": 0.55,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/thedrummer/unslopnemo-12b": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/tngtech/deepseek-r1t2-chimera": {
+    "input": 0.25,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "kilo/undi95/remm-slerp-l2-13b": {
+    "input": 0.45,
+    "output": 0.65,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/upstage/solar-pro-3": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/writer/palmyra-x5": {
+    "input": 0.6,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/x-ai/grok-3": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "kilo/x-ai/grok-3-beta": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "kilo/x-ai/grok-3-mini": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "kilo/x-ai/grok-3-mini-beta": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "kilo/x-ai/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "kilo/x-ai/grok-4-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "kilo/x-ai/grok-4.1-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "kilo/x-ai/grok-4.20-beta": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/x-ai/grok-4.20-multi-agent-beta": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/x-ai/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "kilo/x-ai/grok-code-fast-1:optimized:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/xiaomi/mimo-v2-flash": {
+    "input": 0.09,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0.045
+  },
+  "kilo/z-ai/glm-4-32b": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/z-ai/glm-4.5": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "kilo/z-ai/glm-4.5-air": {
+    "input": 0.13,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "kilo/z-ai/glm-4.5v": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "kilo/z-ai/glm-4.6": {
+    "input": 0.39,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "kilo/z-ai/glm-4.6v": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kilo/z-ai/glm-4.7": {
+    "input": 0.38,
+    "output": 1.98,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "kilo/z-ai/glm-4.7-flash": {
+    "input": 0.06,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "kilo/z-ai/glm-5": {
+    "input": 0.72,
+    "output": 2.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-dev-72b": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-for-coding/k2p5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-for-coding/kimi-k2-thinking": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2-0711": {
+    "input": 0.57,
+    "output": 2.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2-0711-preview": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "kimi-k2-0905-preview": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "kimi-k2-0905:exacto": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2-5": {
+    "input": 0.56,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "kimi-k2-instruct-0711": {
+    "input": 0.1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2-instruct-fast": {
+    "input": 0.1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2-instruct-fp4": {
+    "input": 0.1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "kimi-k2-thinking-maas": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2-thinking-original": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2-thinking-tee": {
+    "input": 0.4,
+    "output": 1.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2-thinking-turbo": {
+    "input": 1.15,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "kimi-k2-thinking-turbo-original": {
+    "input": 1.15,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2-turbo": {
+    "input": 2.4,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2-turbo-preview": {
+    "input": 2.4,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.6
+  },
+  "kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "kimi-k2.5-fast": {
+    "input": 0.5,
+    "output": 2.5,
+    "cacheWrite": 0.625,
+    "cacheRead": 0.05
+  },
+  "kimi-k2.5-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2.5-fw": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2.5-nvfp4": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2.5-tee": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2.5-thinking": {
+    "input": 0.3,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2.5:thinking": {
+    "input": 0.3,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-k2p5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "kimi-k2p5-turbo": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kimi-thinking-preview": {
+    "input": 31.46,
+    "output": 31.46,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "kuae-cloud-coding-plan/glm-4.7": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3-70b-euryale-v2.1": {
+    "input": 1.48,
+    "output": 1.48,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3-8b-lunaris": {
+    "input": 0.05,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3-euryale-70b": {
+    "input": 1.48,
+    "output": 1.48,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3-lunaris-8b": {
+    "input": 0.04,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.1-70b-celeste-v0.1-bf16": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.1-70b-euryale-v2.2": {
+    "input": 0.306,
+    "output": 0.357,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.1-euryale-70b": {
+    "input": 0.85,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.3-70b-euryale-v2.3": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.3-70b-loki-v2.0": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.3-cu-mai-r1-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.3-electra-r1-70b": {
+    "input": 0.69989,
+    "output": 0.69989,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.3-euryale-70b": {
+    "input": 0.65,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.3-ms-evalebis-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.3-ms-evayale-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.3-ms-nevoria-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l3.3-nevoria-r1-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "l31-70b-euryale-v2.2": {
+    "input": 1.48,
+    "output": 1.48,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "labs-devstral-small-2512": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "learnlm-1.5-pro-experimental": {
+    "input": 3.502,
+    "output": 10.506,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lfm-2-24b-a2b": {
+    "input": 0.03,
+    "output": 0.12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lfm-2.2-6b": {
+    "input": 0.01,
+    "output": 0.02,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lfm-2.5-1.2b-instruct:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lfm-2.5-1.2b-thinking:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lfm2-8b-a1b": {
+    "input": 0.01,
+    "output": 0.02,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ling-flash-2.0": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ling-mini-2.0": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-2-7b-chat-fp16": {
+    "input": 0.56,
+    "output": 6.67,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3-70b-instruct": {
+    "input": 0.51,
+    "output": 0.74,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3-8b-instruct-awq": {
+    "input": 0.12,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3-lumimaid-70b-v0.1": {
+    "input": 2.006,
+    "output": 2.006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.05-nemotron-tenyxchat-storybreaker-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.05-nt-storybreaker-ministral-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-405b": {
+    "input": 4,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-70b": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-70b-instruct-turbo": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-8b": {
+    "input": 0.03,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-8b-instant": {
+    "input": 0.05,
+    "output": 0.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-8b-instruct-awq": {
+    "input": 0.12,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-8b-instruct-fp8": {
+    "input": 0.15,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-8b-instruct-turbo": {
+    "input": 0.02,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-nemotron-51b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-nemotron-70b-instruct": {
+    "input": 1.2,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-nemotron-70b-instruct-hf": {
+    "input": 0.357,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-nemotron-70b-instruct-hf-abliterated": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-nemotron-ultra-253b": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.1-nemotron-ultra-253b-v1": {
+    "input": 0.4,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.2-11b": {
+    "input": 0.16,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.2-11b-instruct": {
+    "input": 0.07,
+    "output": 0.33,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.2-1b": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.2-3b-instruct:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.2-90b": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3+(3.1v3.3)-70b-hanami-x1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3+(3.1v3.3)-70b-new-dawn-v1.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3+(3v3.3)-70b-tenyxchat-daybreakstorywriter": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b": {
+    "input": 0.7,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-anthrobomination": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-argunaut-1-sft": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-arliai-rpmax-v1.4": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-arliai-rpmax-v2": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-arliai-rpmax-v3": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-aurora-borealis": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-bigger-body": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-cirrus-x1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-cu-mai-r1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-damascus-r1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-dark-ages-v0.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-electra-r1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-electranova-v1.0": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-fallen-r1-v1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-fallen-v1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-forgotten-abomination-v5.0": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-forgotten-safeword-3.6": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-geneticlemonade-opus": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-geneticlemonade-unleashed-v3": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-ignition-v0.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-incandescent-malevolence": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-instruct-abliterated": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-instruct-fast": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0.31,
+    "cacheRead": 0.025
+  },
+  "llama-3.3-70b-instruct-fp8": {
+    "input": 1.18,
+    "output": 1.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-instruct-fp8-dynamic": {
+    "input": 0.49,
+    "output": 0.71,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-instruct-fp8-fast": {
+    "input": 0.29,
+    "output": 2.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-instruct-maas": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-instruct:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-legion-v2.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-magnum-v4-se": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-magnum-v4-se-cirrus-x1-slerp": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-mhnnn-x1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-miraifanfare": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-mokume-gane-r1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-ms-nevoria": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-nova": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-predatorial-extasy": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-progenitor-v3.3": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-rawmaw": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-sapphira-0.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-sapphira-0.2": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-shakudo": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-strawberrylemonade-v1.0": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-strawberrylemonade-v1.2": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-the-omega-directive-unslop-v2.0": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-the-omega-directive-unslop-v2.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-versatile": {
+    "input": 0.59,
+    "output": 0.79,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-70b-vulpecula-r1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-8b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-nemotron-super-49b-v1": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3.3-nemotron-super-49b-v1.5": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-3_1-nemotron-ultra-253b-v1": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0.75,
+    "cacheRead": 0.06
+  },
+  "llama-3_3-nemotron-super-49b-v1_5": {
+    "input": 0.05,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-4-maverick-17b-128e-instruct": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-4-maverick-17b-128e-instruct-maas": {
+    "input": 0.35,
     "output": 1.15,
-    "cacheWrite": 1.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-4-maverick-17b-instruct": {
+    "input": 0.24,
+    "output": 0.97,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-4-scout-17b-16e-instruct-fp8": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-4-scout-17b-instruct": {
+    "input": 0.17,
+    "output": 0.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-embed-nemotron-8b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-guard-4": {
+    "input": 0.21,
+    "output": 0.21,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama-xlam-2-70b-fc-r": {
+    "input": 2.5,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama/cerebras-llama-4-maverick-17b-128e-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama/cerebras-llama-4-scout-17b-16e-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama/groq-llama-4-maverick-17b-128e-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama/llama-3.3-70b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama/llama-3.3-8b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama/llama-4-maverick-17b-128e-instruct-fp8": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama/llama-4-scout-17b-16e-instruct-fp8": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama3-3-70b": {
+    "input": 2,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama3-70b-8192": {
+    "input": 0.59,
+    "output": 0.79,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama3-70b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama3-8b-8192": {
+    "input": 0.05,
+    "output": 0.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama3-8b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama3-chatqa-1.5-70b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llama3.1-8b": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llemma_7b": {
+    "input": 0.8,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/auto": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/claude-3-5-haiku": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "llmgateway/claude-3-5-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "llmgateway/claude-3-5-sonnet-20241022": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "llmgateway/claude-3-7-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "llmgateway/claude-3-7-sonnet-20250219": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "llmgateway/claude-3-haiku": {
+    "input": 0.25,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/claude-3-haiku-20240307": {
+    "input": 0.25,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/claude-3-opus": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 0,
+    "cacheRead": 1.5
+  },
+  "llmgateway/claude-haiku-4-5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "llmgateway/claude-haiku-4-5-20251001": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "llmgateway/claude-opus-4-1-20250805": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 0,
+    "cacheRead": 1.5
+  },
+  "llmgateway/claude-opus-4-20250514": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 0,
+    "cacheRead": 1.5
+  },
+  "llmgateway/claude-opus-4-5-20251101": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "llmgateway/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "llmgateway/claude-sonnet-4-20250514": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "llmgateway/claude-sonnet-4-5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "llmgateway/claude-sonnet-4-5-20250929": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "llmgateway/claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "llmgateway/codestral-2508": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/cogview-4": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/custom": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/deepseek-r1-0528": {
+    "input": 0.8,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/deepseek-v3.1": {
+    "input": 0.56,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "llmgateway/deepseek-v3.2": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/devstral-2512": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/devstral-small-2507": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gemini-2.0-flash": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/gemini-2.0-flash-lite": {
+    "input": 0.08,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/gemini-2.5-flash-image": {
+    "input": 0.3,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/gemini-2.5-flash-image-preview": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gemini-2.5-flash-lite": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "llmgateway/gemini-2.5-flash-lite-preview-09-2025": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "llmgateway/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "llmgateway/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "llmgateway/gemini-3-pro-image-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "llmgateway/gemini-3.1-flash-image-preview": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gemini-3.1-flash-lite-preview": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/gemini-3.1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "llmgateway/gemini-pro-latest": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "llmgateway/gemma-2-27b-it-together": {
+    "input": 0.08,
+    "output": 0.08,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gemma-3-12b-it": {
+    "input": 0.08,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gemma-3-1b-it": {
+    "input": 0.08,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gemma-3-27b": {
+    "input": 0.27,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gemma-3-4b-it": {
+    "input": 0.08,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gemma-3n-e2b-it": {
+    "input": 0.08,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gemma-3n-e4b-it": {
+    "input": 0.08,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/glm-4-32b-0414-128k": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/glm-4.5": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "llmgateway/glm-4.5-air": {
+    "input": 0.2,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/glm-4.5-airx": {
+    "input": 1.1,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.22
+  },
+  "llmgateway/glm-4.5-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/glm-4.5-x": {
+    "input": 2.2,
+    "output": 8.9,
+    "cacheWrite": 0,
+    "cacheRead": 0.45
+  },
+  "llmgateway/glm-4.5v": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "llmgateway/glm-4.6": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "llmgateway/glm-4.6v": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "llmgateway/glm-4.6v-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/glm-4.6v-flashx": {
+    "input": 0.04,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "llmgateway/glm-4.7-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/glm-4.7-flashx": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "llmgateway/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "llmgateway/glm-image": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gpt-3.5-turbo": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gpt-4": {
+    "input": 30,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gpt-4-turbo": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "llmgateway/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "llmgateway/gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/gpt-4o": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "llmgateway/gpt-4o-mini": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "llmgateway/gpt-4o-mini-search-preview": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gpt-4o-search-preview": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "llmgateway/gpt-5-chat-latest": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "llmgateway/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "llmgateway/gpt-5-pro": {
+    "input": 15,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "llmgateway/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.18
+  },
+  "llmgateway/gpt-5.2-chat-latest": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.18
+  },
+  "llmgateway/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.18
+  },
+  "llmgateway/gpt-5.2-pro": {
+    "input": 21,
+    "output": 168,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gpt-5.3-chat-latest": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.18
+  },
+  "llmgateway/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.18
+  },
+  "llmgateway/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "llmgateway/gpt-5.4-mini": {
+    "input": 0.75,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "llmgateway/gpt-5.4-nano": {
+    "input": 0.2,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "llmgateway/gpt-5.4-pro": {
+    "input": 30,
+    "output": 180,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gpt-oss-120b": {
+    "input": 0.15,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/gpt-oss-20b": {
+    "input": 0.1,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/grok-3": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/grok-4-0709": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/grok-4-1-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "llmgateway/grok-4-1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "llmgateway/grok-4-1-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "llmgateway/grok-4-20-beta-0309-non-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "llmgateway/grok-4-20-beta-0309-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "llmgateway/grok-4-20-multi-agent-beta-0309": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "llmgateway/grok-4-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "llmgateway/grok-4-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "llmgateway/grok-4-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "llmgateway/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/grok-imagine-image": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/grok-imagine-image-pro": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/hermes-2-pro-llama-3-8b": {
+    "input": 0.14,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/kimi-k2": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "llmgateway/kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "llmgateway/kimi-k2-thinking-turbo": {
+    "input": 1.15,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "llmgateway/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "llmgateway/llama-3-70b-instruct": {
+    "input": 0.51,
+    "output": 0.74,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/llama-3-8b-instruct": {
+    "input": 0.04,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/llama-3.1-70b-instruct": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/llama-3.1-8b-instruct": {
+    "input": 0.22,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/llama-3.1-nemotron-ultra-253b": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/llama-3.2-11b-instruct": {
+    "input": 0.07,
+    "output": 0.33,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/llama-3.2-3b-instruct": {
+    "input": 0.03,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/llama-3.3-70b-instruct": {
+    "input": 0.13,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/llama-4-maverick-17b-instruct": {
+    "input": 0.24,
+    "output": 0.97,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/llama-4-scout": {
+    "input": 0.18,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/llama-4-scout-17b-instruct": {
+    "input": 0.17,
+    "output": 0.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/llama-guard-4-12b": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/minimax-m2": {
+    "input": 0.2,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/minimax-m2.1": {
+    "input": 0.27,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/minimax-m2.1-lightning": {
+    "input": 0.12,
+    "output": 0.48,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/minimax-m2.5-highspeed": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "llmgateway/minimax-m2.7": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "llmgateway/minimax-m2.7-highspeed": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "llmgateway/minimax-text-01": {
+    "input": 0.2,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/ministral-14b-2512": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/ministral-3b-2512": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/ministral-8b-2512": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/mistral-large-2512": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/mistral-large-latest": {
+    "input": 4,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/mistral-small-2506": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/mixtral-8x7b-instruct-together": {
+    "input": 0.06,
+    "output": 0.06,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/o1": {
+    "input": 15,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 7.5
+  },
+  "llmgateway/o3": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "llmgateway/o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "llmgateway/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
     "cacheRead": 0.28
+  },
+  "llmgateway/pixtral-large-latest": {
+    "input": 4,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-coder-plus": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-flash": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "llmgateway/qwen-image": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-image-edit-max": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-image-edit-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-image-max": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-image-max-2025-12-30": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-image-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-max": {
+    "input": 1.6,
+    "output": 6.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-max-latest": {
+    "input": 1.6,
+    "output": 6.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-omni-turbo": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-plus": {
+    "input": 0.4,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "llmgateway/qwen-plus-latest": {
+    "input": 0.4,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "llmgateway/qwen-turbo": {
+    "input": 0.05,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-vl-max": {
+    "input": 0.8,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen-vl-plus": {
+    "input": 0.21,
+    "output": 0.64,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen2-5-vl-32b-instruct": {
+    "input": 1.4,
+    "output": 4.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen2-5-vl-72b-instruct": {
+    "input": 0.13,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen25-coder-7b": {
+    "input": 0.01,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-235b-a22b-fp8": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-30b-a3b-fp8": {
+    "input": 0.09,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-30b-a3b-instruct-2507": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-30b-a3b-thinking-2507": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-32b": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-32b-fp8": {
+    "input": 0.1,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-4b-fp8": {
+    "input": 0.03,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.4,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-coder-flash": {
+    "input": 0.3,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "llmgateway/qwen3-coder-next": {
+    "input": 0.11,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "llmgateway/qwen3-coder-plus": {
+    "input": 6,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-max": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.6
+  },
+  "llmgateway/qwen3-max-2026-01-23": {
+    "input": 1.2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "llmgateway/qwen3-next-80b-a3b-instruct": {
+    "input": 0.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-next-80b-a3b-thinking": {
+    "input": 0.5,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-vl-235b-a22b-instruct": {
+    "input": 0.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-vl-235b-a22b-thinking": {
+    "input": 0.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-vl-30b-a3b-instruct": {
+    "input": 0.2,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-vl-30b-a3b-thinking": {
+    "input": 0.2,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-vl-8b-instruct": {
+    "input": 0.08,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwen3-vl-flash": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "llmgateway/qwen3-vl-plus": {
+    "input": 0.2,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "llmgateway/qwen35-397b-a17b": {
+    "input": 0.6,
+    "output": 3.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/qwq-plus": {
+    "input": 0.8,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/seed-1-6-250615": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "llmgateway/seed-1-6-250915": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "llmgateway/seed-1-6-flash-250715": {
+    "input": 0.07,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "llmgateway/seed-1-8-251228": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "llmgateway/seedream-4-0": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/seedream-4-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/sonar": {
+    "input": 1,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/sonar-pro": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/sonar-reasoning-pro": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/veo-3.1-fast-generate-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "llmgateway/veo-3.1-generate-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lmstudio/openai/gpt-oss-20b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lmstudio/qwen/qwen3-30b-a3b-2507": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lmstudio/qwen/qwen3-coder-30b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "longcat-flash-chat": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "longcat-flash-chat-fp8": {
+    "input": 0.15,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "longcat-flash-thinking": {
+    "input": 0.15,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lucidnova-rf1-100b": {
+    "input": 2,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lucidquery-nexus-coder": {
+    "input": 2,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lucidquery/lucidnova-rf1-100b": {
+    "input": 2,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lucidquery/lucidquery-nexus-coder": {
+    "input": 2,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "lumimaid-v0.2-70b": {
+    "input": 1,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "m2m100-1.2b": {
+    "input": 0.34,
+    "output": 0.34,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "maestro-reasoning": {
+    "input": 0.9,
+    "output": 3.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "magidonia-24b-v4.3": {
+    "input": 0.1003,
+    "output": 0.1207,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "magistral-medium": {
+    "input": 2,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "magistral-medium-latest": {
+    "input": 2,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "magistral-small": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "magistral-small-2509": {
+    "input": 0.59,
+    "output": 2.36,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "magnum-v2-72b": {
+    "input": 2.006,
+    "output": 2.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mai-ds-r1-fp8": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mamba-codestral-7b-v0.1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "manta-flash-1.0": {
+    "input": 0.02,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "manta-mini-1.0": {
+    "input": 0.02,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "manta-pro-1.0": {
+    "input": 0.06,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/deepseek-ai/deepseek-r1-0528": {
+    "input": 0.5,
+    "output": 2.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/deepseek-ai/deepseek-v3-0324": {
+    "input": 0.25,
+    "output": 0.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/deepseek-ai/deepseek-v3.1": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/deepseek-ai/deepseek-v3.2": {
+    "input": 0.26,
+    "output": 0.38,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/deepseek-ai/deepseek-v3.2-exp": {
+    "input": 0.27,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/meta-llama/llama-3.3-70b-instruct": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/minimaxai/minimax-m2.1": {
+    "input": 0.28,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/minimaxai/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/mistralai/mistral-nemo-instruct-2407": {
+    "input": 0.02,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/mistralai/mistral-small-3.2-24b-instruct-2506": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/moonshotai/kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/moonshotai/kimi-k2.5": {
+    "input": 0.45,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/qwen/qwen2.5-vl-32b-instruct": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/qwen/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.09,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/qwen/qwen3.5-plus": {
+    "input": 0.4,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/xiaomimimo/mimo-v2-flash": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/zai-org/glm-4.6": {
+    "input": 0.45,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/zai-org/glm-4.7": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meganova/zai-org/glm-5": {
+    "input": 0.8,
+    "output": 2.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "melotts": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mercury-2": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "mercury-coder-small": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mercury-edit": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "meta-llama-3-1-8b-instruct-fp8": {
+    "input": 0.02,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta-llama-3-70b-instruct-abliterated-v3.5": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta-llama-3.1-405b-instruct-turbo": {
+    "input": 3.5,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta-llama-3.1-8b-instruct-fast": {
+    "input": 0.03,
+    "output": 0.09,
+    "cacheWrite": 0.03,
+    "cacheRead": 0.003
+  },
+  "meta-llama-3.1-8b-instruct-fp8": {
+    "input": 0.16,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta-llama-3_3-70b-instruct": {
+    "input": 0.74,
+    "output": 0.74,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta.llama3-1-405b-instruct-v1:0": {
+    "input": 2.4,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta.llama3-1-70b-instruct-v1:0": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta.llama3-1-8b-instruct-v1:0": {
+    "input": 0.22,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta.llama3-2-11b-instruct-v1:0": {
+    "input": 0.16,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta.llama3-2-1b-instruct-v1:0": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta.llama3-2-3b-instruct-v1:0": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta.llama3-2-90b-instruct-v1:0": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta.llama3-3-70b-instruct-v1:0": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta.llama4-maverick-17b-instruct-v1:0": {
+    "input": 0.24,
+    "output": 0.97,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "meta.llama4-scout-17b-instruct-v1:0": {
+    "input": 0.17,
+    "output": 0.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mimo-v2-flash": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "mimo-v2-flash-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mimo-v2-flash-original": {
+    "input": 0.102,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mimo-v2-flash-thinking": {
+    "input": 0.102,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mimo-v2-flash-thinking-original": {
+    "input": 0.102,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mimo-v2-omni": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "mimo-v2-omni-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mimo-v2-pro": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "mimo-v2-pro-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mimo-v2-tts": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-cn-coding-plan/minimax-m2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-cn-coding-plan/minimax-m2.1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-cn-coding-plan/minimax-m2.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-cn-coding-plan/minimax-m2.5-highspeed": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-cn-coding-plan/minimax-m2.7": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-cn-coding-plan/minimax-m2.7-highspeed": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-cn/minimax-m2": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-cn/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-cn/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.03
+  },
+  "minimax-cn/minimax-m2.5-highspeed": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "minimax-cn/minimax-m2.7": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "minimax-cn/minimax-m2.7-highspeed": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "minimax-coding-plan/minimax-m2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-coding-plan/minimax-m2.1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-coding-plan/minimax-m2.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-coding-plan/minimax-m2.5-highspeed": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-coding-plan/minimax-m2.7": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-coding-plan/minimax-m2.7-highspeed": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-m2": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-m2-5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-m2.1-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-m2.1-tee": {
+    "input": 0.27,
+    "output": 1.12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.03
+  },
+  "minimax-m2.5-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-m2.5-highspeed": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "minimax-m2.5-lightning": {
+    "input": 0.6,
+    "output": 4.8,
+    "cacheWrite": 0.75,
+    "cacheRead": 0.06
+  },
+  "minimax-m2.5-tee": {
+    "input": 0.3,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "minimax-m2.5:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-m2.7": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "minimax-m2.7-highspeed": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "minimax-m21": {
+    "input": 0.35,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "minimax-m27": {
+    "input": 0.375,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "minimax-m2_5-high-throughput": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax-m2p1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "minimax-m2p5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "minimax-text-01": {
+    "input": 0.2,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax.minimax-m2": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax.minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax.minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "minimax/minimax-m2": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
   },
   "minimax/minimax-m2.1": {
     "input": 0.3,
@@ -1151,125 +17189,641 @@
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistral-large": {
+  "minimax/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.03
+  },
+  "minimax/minimax-m2.5-highspeed": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "minimax/minimax-m2.7": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "minimax/minimax-m2.7-highspeed": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "ministral-14b": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ministral-14b-instruct-2512": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ministral-3-14b-reasoning-2512": {
+    "input": 2.5,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ministral-3-3b-reasoning-2512": {
+    "input": 1.039,
+    "output": 0.54825,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ministral-3b-2512": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ministral-3b-latest": {
+    "input": 0.04,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ministral-8b": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ministral-8b-2512": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ministral-8b-latest": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-7b-instruct": {
+    "input": 0.0544,
+    "output": 0.0544,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-7b-instruct-v0.1": {
+    "input": 0.11,
+    "output": 0.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-7b-instruct-v0.3": {
+    "input": 0.11,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-embed": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-large-2-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-large-2407": {
     "input": 2,
     "output": 6,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistral-small": {
-    "input": 0.2,
-    "output": 0.6,
+  "mistral-large-3": {
+    "input": 0.5,
+    "output": 1.5,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/codestral-2508": {
-    "input": 0.3,
-    "output": 0.9,
+  "mistral-large-3-675b-instruct-2512": {
+    "input": 1,
+    "output": 3,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/devstral-2512": {
-    "input": 0.15,
-    "output": 0.6,
-    "cacheWrite": 0,
-    "cacheRead": 0
+  "mistral-large-instruct-2411": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 4,
+    "cacheRead": 1
   },
-  "mistralai/devstral-2512:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "mistralai/devstral-medium-2507": {
+  "mistral-medium": {
     "input": 0.4,
     "output": 2,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/devstral-small-2505": {
-    "input": 0.06,
-    "output": 0.12,
+  "mistral-medium-2508": {
+    "input": 0.4,
+    "output": 2,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/devstral-small-2505:free": {
-    "input": 0,
-    "output": 0,
+  "mistral-medium-3": {
+    "input": 0.4,
+    "output": 2,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/devstral-small-2507": {
+  "mistral-medium-3.1": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-medium-latest": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-nemo-12b-instruct": {
+    "input": 0.038,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-nemo-12b-instruct-2407": {
+    "input": 0.01,
+    "output": 0.01,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-nemo-instruct-2407-fp8": {
+    "input": 0.49,
+    "output": 0.71,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-saba-24b": {
+    "input": 0.79,
+    "output": 0.79,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-small-2506": {
     "input": 0.1,
     "output": 0.3,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/mistral-7b-instruct:free": {
-    "input": 0,
-    "output": 0,
+  "mistral-small-2603": {
+    "input": 0.15,
+    "output": 0.6,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/mistral-medium-3": {
+  "mistral-small-3-2-24b-instruct": {
+    "input": 0.09375,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-small-3.1-24b-instruct-2503": {
+    "input": 0.03,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0.015
+  },
+  "mistral-small-3.2-24b-instruct": {
+    "input": 0.06,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "mistral-small-31-24b-instruct": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-small-creative": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-small-latest": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral-tiny": {
+    "input": 0.255,
+    "output": 0.255,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral.devstral-2-123b": {
     "input": 0.4,
     "output": 2,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/mistral-medium-3.1": {
+  "mistral.magistral-small-2509": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral.ministral-3-14b-instruct": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral.ministral-3-3b-instruct": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral.ministral-3-8b-instruct": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral.mistral-large-3-675b-instruct": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral.pixtral-large-2502-v1:0": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral.voxtral-mini-3b-2507": {
+    "input": 0.04,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral.voxtral-small-24b-2507": {
+    "input": 0.15,
+    "output": 0.35,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/codestral-latest": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/devstral-2512": {
     "input": 0.4,
     "output": 2,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/mistral-nemo:free": {
+  "mistral/devstral-medium-2507": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/devstral-medium-latest": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/devstral-small-2505": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/devstral-small-2507": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/labs-devstral-small-2512": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/mistral-small-3.1-24b-instruct": {
+  "mistral/magistral-medium-latest": {
+    "input": 2,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/magistral-small": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/ministral-3b-latest": {
+    "input": 0.04,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/ministral-8b-latest": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/mistral-embed": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/mistral-large-2411": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/mistral-large-2512": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/mistral-large-latest": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/mistral-medium-2505": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/mistral-medium-2508": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/mistral-medium-latest": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/mistral-nemo": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/mistral-small-2506": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/mistral-small-2603": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/mistral-small-latest": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/open-mistral-7b": {
+    "input": 0.25,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/open-mixtral-8x22b": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/open-mixtral-8x7b": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/pixtral-12b": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mistral/pixtral-large-latest": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mixtral-8x22b-instruct": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mixtral-8x22b-instruct-v0.1": {
+    "input": 0.9,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mixtral-8x7b-instruct": {
+    "input": 0.54,
+    "output": 0.54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mixtral-8x7b-instruct-together": {
+    "input": 0.06,
+    "output": 0.06,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mm-poly-8b": {
+    "input": 0.658,
+    "output": 1.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mn-12b-inferor-v0.0": {
+    "input": 0.255,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mn-12b-mag-mell-r1": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "mn-loosecannon-12b-v1": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "moark/glm-4.7": {
+    "input": 3.5,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "moark/minimax-m2.1": {
+    "input": 2.1,
+    "output": 8.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "model-router": {
+    "input": 0.14,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "modelscope/qwen/qwen3-235b-a22b-instruct-2507": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/mistral-small-3.2-24b-instruct": {
+  "modelscope/qwen/qwen3-235b-a22b-thinking-2507": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "mistralai/mistral-small-3.2-24b-instruct:free": {
+  "modelscope/qwen/qwen3-30b-a3b-instruct-2507": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "moonshotai/kimi-dev-72b:free": {
+  "modelscope/qwen/qwen3-30b-a3b-thinking-2507": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "moonshotai/kimi-k2": {
-    "input": 0.55,
-    "output": 2.2,
+  "modelscope/qwen/qwen3-coder-30b-a3b-instruct": {
+    "input": 0,
+    "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "moonshotai/kimi-k2-0905": {
+  "modelscope/zhipuai/glm-4.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "modelscope/zhipuai/glm-4.6": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "molmo-2-8b": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "moonshot-kimi-k2-instruct": {
+    "input": 0.574,
+    "output": 2.294,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "moonshot.kimi-k2-thinking": {
     "input": 0.6,
     "output": 2.5,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "moonshotai/kimi-k2-0905:exacto": {
+  "moonshotai-cn/kimi-k2-0711-preview": {
     "input": 0.6,
     "output": 2.5,
     "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "moonshotai-cn/kimi-k2-0905-preview": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "moonshotai-cn/kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "moonshotai-cn/kimi-k2-thinking-turbo": {
+    "input": 1.15,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "moonshotai-cn/kimi-k2-turbo-preview": {
+    "input": 2.4,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.6
+  },
+  "moonshotai-cn/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "moonshotai.kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
     "cacheRead": 0
+  },
+  "moonshotai/kimi-k2-0711-preview": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "moonshotai/kimi-k2-0905-preview": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
   },
   "moonshotai/kimi-k2-thinking": {
     "input": 0.6,
@@ -1277,11 +17831,17 @@
     "cacheWrite": 0,
     "cacheRead": 0.15
   },
-  "moonshotai/kimi-k2:free": {
-    "input": 0,
-    "output": 0,
+  "moonshotai/kimi-k2-thinking-turbo": {
+    "input": 1.15,
+    "output": 8,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 0.15
+  },
+  "moonshotai/kimi-k2-turbo-preview": {
+    "input": 2.4,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.6
   },
   "moonshotai/kimi-k2.5": {
     "input": 0.6,
@@ -1289,49 +17849,4579 @@
     "cacheWrite": 0,
     "cacheRead": 0.1
   },
-  "nousresearch/deephermes-3-llama-3-8b-preview": {
+  "morph-v3-fast": {
+    "input": 0.8,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "morph-v3-large": {
+    "input": 0.9,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "morph-warp-grep-v2": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "nousresearch/hermes-3-llama-3.1-405b:free": {
+  "morph/auto": {
+    "input": 0.85,
+    "output": 1.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "morph/morph-v3-fast": {
+    "input": 0.8,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "morph/morph-v3-large": {
+    "input": 0.9,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ms3.2-24b-magnum-diamond": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ms3.2-the-omega-directive-24b-unslop-v2.0": {
+    "input": 0.5,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "multilingual-e5-large": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-banana": {
+    "input": 0.21,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.021
+  },
+  "nano-banana-pro": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "nano-gpt/abacusai/dracarys-72b-instruct": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/aion-labs/aion-1.0": {
+    "input": 3.995,
+    "output": 7.99,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/aion-labs/aion-1.0-mini": {
+    "input": 0.799,
+    "output": 1.394,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/aion-labs/aion-rp-llama-3.1-8b": {
+    "input": 0.2006,
+    "output": 0.2006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/alibaba-nlp/tongyi-deepresearch-30b-a3b": {
+    "input": 0.08,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/allenai/molmo-2-8b": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/allenai/olmo-3-32b-think": {
+    "input": 0.3,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/allenai/olmo-3.1-32b-instruct": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/allenai/olmo-3.1-32b-think": {
+    "input": 0.15,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/amazon/nova-2-lite-v1": {
+    "input": 0.51,
+    "output": 4.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/amazon/nova-lite-v1": {
+    "input": 0.0595,
+    "output": 0.238,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/amazon/nova-micro-v1": {
+    "input": 0.0357,
+    "output": 0.1394,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/amazon/nova-pro-v1": {
+    "input": 0.799,
+    "output": 3.196,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/anthracite-org/magnum-v2-72b": {
+    "input": 2.006,
+    "output": 2.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/anthracite-org/magnum-v4-72b": {
+    "input": 2.006,
+    "output": 2.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/anthropic/claude-opus-4.6": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/anthropic/claude-opus-4.6:thinking": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/anthropic/claude-opus-4.6:thinking:low": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/anthropic/claude-opus-4.6:thinking:max": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/anthropic/claude-opus-4.6:thinking:medium": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/anthropic/claude-sonnet-4.6": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/anthropic/claude-sonnet-4.6:thinking": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/arcee-ai/trinity-large": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/arcee-ai/trinity-mini": {
+    "input": 0.045,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/asi1-mini": {
+    "input": 1,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/auto-model": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "nousresearch/hermes-4-405b": {
+  "nano-gpt/auto-model-basic": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/auto-model-premium": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/auto-model-standard": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/azure-gpt-4-turbo": {
+    "input": 9.996,
+    "output": 30.005,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/azure-gpt-4o": {
+    "input": 2.499,
+    "output": 9.996,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/azure-gpt-4o-mini": {
+    "input": 0.1496,
+    "output": 0.595,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/azure-o1": {
+    "input": 14.994,
+    "output": 59.993,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/azure-o3-mini": {
+    "input": 1.088,
+    "output": 4.3996,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/baichuan-m2": {
+    "input": 15.73,
+    "output": 15.73,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/baichuan4-air": {
+    "input": 0.157,
+    "output": 0.157,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/baichuan4-turbo": {
+    "input": 2.42,
+    "output": 2.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/baidu/ernie-4.5-300b-a47b": {
+    "input": 0.35,
+    "output": 1.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/baidu/ernie-4.5-vl-28b-a3b": {
+    "input": 0.14,
+    "output": 0.56,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/baseten/kimi-k2-instruct-fp4": {
+    "input": 0.1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/brave": {
+    "input": 5,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/brave-pro": {
+    "input": 5,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/brave-research": {
+    "input": 5,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/chutesai/mistral-small-3.2-24b-instruct-2506": {
+    "input": 0.2,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-3-5-haiku-20241022": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-3-5-sonnet-20240620": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-3-5-sonnet-20241022": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-3-7-sonnet-20250219": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-3-7-sonnet-reasoner": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-3-7-sonnet-thinking": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-3-7-sonnet-thinking:1024": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-3-7-sonnet-thinking:128000": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-3-7-sonnet-thinking:32768": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-3-7-sonnet-thinking:8192": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-haiku-4-5-20251001": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-1-20250805": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-1-thinking": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-1-thinking:1024": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-1-thinking:32000": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-1-thinking:32768": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-1-thinking:8192": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-20250514": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-5-20251101": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-5-20251101:thinking": {
+    "input": 4.998,
+    "output": 25.007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-thinking": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-thinking:1024": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-thinking:32000": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-thinking:32768": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-opus-4-thinking:8192": {
+    "input": 14.994,
+    "output": 75.004,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-sonnet-4-20250514": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-sonnet-4-5-20250929": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-sonnet-4-5-20250929-thinking": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-sonnet-4-thinking": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-sonnet-4-thinking:1024": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-sonnet-4-thinking:32768": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-sonnet-4-thinking:64000": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/claude-sonnet-4-thinking:8192": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/cognitivecomputations/dolphin-2.9.2-qwen2-72b": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/cohere/command-r": {
+    "input": 0.476,
+    "output": 1.428,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/cohere/command-r-plus-08-2024": {
+    "input": 2.856,
+    "output": 14.246,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/command-a-reasoning-08-2025": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/cruciblelab/l3.3-70b-loki-v2.0": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepclaude": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepcogito/cogito-v1-preview-qwen-32b": {
+    "input": 1.8,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepcogito/cogito-v2.1-671b": {
+    "input": 1.25,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-ai/deepseek-r1-0528": {
+    "input": 0.4,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-ai/deepseek-v3.1": {
+    "input": 0.2,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-ai/deepseek-v3.1-terminus": {
+    "input": 0.25,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-ai/deepseek-v3.1-terminus:thinking": {
+    "input": 0.25,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-ai/deepseek-v3.1:thinking": {
+    "input": 0.2,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-ai/deepseek-v3.2-exp": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-ai/deepseek-v3.2-exp-thinking": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-chat": {
+    "input": 0.25,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-chat-cheaper": {
+    "input": 0.25,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-math-v2": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-r1": {
+    "input": 0.4,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-r1-sambanova": {
+    "input": 4.998,
+    "output": 6.987,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-reasoner": {
+    "input": 0.4,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-reasoner-cheaper": {
+    "input": 0.4,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek-v3-0324": {
+    "input": 0.25,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek/deepseek-prover-v2-671b": {
+    "input": 1,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek/deepseek-v3.2": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek/deepseek-v3.2-speciale": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/deepseek/deepseek-v3.2:thinking": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/dmind/dmind-1": {
+    "input": 0.3,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/dmind/dmind-1-mini": {
+    "input": 0.2,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doctor-shotgun/ms3.2-24b-magnum-diamond": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-1-5-thinking-pro-250415": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-1-5-thinking-pro-vision-250415": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-1-5-thinking-vision-pro-250428": {
+    "input": 0.55,
+    "output": 1.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-1.5-pro-256k": {
+    "input": 0.799,
+    "output": 1.445,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-1.5-pro-32k": {
+    "input": 0.1343,
+    "output": 0.3349,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-1.5-vision-pro-32k": {
+    "input": 0.459,
+    "output": 1.377,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-seed-1-6-250615": {
+    "input": 0.204,
+    "output": 0.51,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-seed-1-6-flash-250615": {
+    "input": 0.0374,
+    "output": 0.374,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-seed-1-6-thinking-250615": {
+    "input": 0.204,
+    "output": 2.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-seed-1-8-251215": {
+    "input": 0.612,
+    "output": 6.12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-seed-2-0-code-preview-260215": {
+    "input": 0.782,
+    "output": 3.893,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-seed-2-0-lite-260215": {
+    "input": 0.1462,
+    "output": 0.8738,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-seed-2-0-mini-260215": {
+    "input": 0.0493,
+    "output": 0.4845,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-seed-2-0-pro-260215": {
+    "input": 0.782,
+    "output": 3.876,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/doubao-seed-code-preview-latest": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/envoid/llama-3.05-nemotron-tenyxchat-storybreaker-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/envoid/llama-3.05-nt-storybreaker-ministral-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/ernie-4.5-8k-preview": {
+    "input": 0.66,
+    "output": 2.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/ernie-4.5-turbo-128k": {
+    "input": 0.132,
+    "output": 0.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/ernie-4.5-turbo-vl-32k": {
+    "input": 0.495,
+    "output": 1.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/ernie-5.0-thinking-latest": {
+    "input": 1.1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/ernie-5.0-thinking-preview": {
+    "input": 1.1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/ernie-x1-32k": {
+    "input": 0.33,
+    "output": 1.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/ernie-x1-32k-preview": {
+    "input": 0.33,
+    "output": 1.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/ernie-x1-turbo-32k": {
+    "input": 0.165,
+    "output": 0.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/ernie-x1.1-preview": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/essentialai/rnj-1-instruct": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/eva-unit-01/eva-llama-3.33-70b-v0.0": {
+    "input": 2.006,
+    "output": 2.006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/eva-unit-01/eva-llama-3.33-70b-v0.1": {
+    "input": 2.006,
+    "output": 2.006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/eva-unit-01/eva-qwen2.5-32b-v0.2": {
+    "input": 0.799,
+    "output": 0.799,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/eva-unit-01/eva-qwen2.5-72b-v0.2": {
+    "input": 0.799,
+    "output": 0.799,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/exa-answer": {
+    "input": 2.5,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/exa-research": {
+    "input": 2.5,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/exa-research-pro": {
+    "input": 2.5,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/failspy/meta-llama-3-70b-instruct-abliterated-v3.5": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/fastgpt": {
+    "input": 7.5,
+    "output": 7.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/featherless-ai/qwerky-72b": {
+    "input": 0.5,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/galrionsoftworks/mn-loosecannon-12b-v1": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.0-flash-001": {
+    "input": 0.1003,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.0-flash-exp-image-generation": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.0-flash-lite": {
+    "input": 0.0748,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.0-flash-thinking-exp-01-21": {
+    "input": 0.306,
+    "output": 1.003,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.0-flash-thinking-exp-1219": {
+    "input": 0.1003,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.0-pro-exp-02-05": {
+    "input": 1.989,
+    "output": 7.956,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.0-pro-reasoner": {
+    "input": 1.292,
+    "output": 4.998,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash-lite": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash-lite-preview-06-17": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash-lite-preview-09-2025": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash-lite-preview-09-2025-thinking": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash-nothinking": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash-preview-04-17": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash-preview-04-17:thinking": {
+    "input": 0.15,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash-preview-05-20": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash-preview-05-20:thinking": {
+    "input": 0.15,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash-preview-09-2025": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-flash-preview-09-2025-thinking": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-pro": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-pro-exp-03-25": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-pro-preview-03-25": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-pro-preview-05-06": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-2.5-pro-preview-06-05": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-3-pro-image-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-3-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-3-pro-preview-thinking": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemini-exp-1206": {
+    "input": 1.258,
+    "output": 4.998,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemma-3-27b-arliai-rpmax-v3": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemma-3-27b-big-tiger-v3": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemma-3-27b-cardprojector-v4": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemma-3-27b-glitter": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemma-3-27b-it": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemma-3-27b-it-abliterated": {
+    "input": 0.42,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gemma-3-27b-nidum-uncensored": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4": {
+    "input": 14.994,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4-air": {
+    "input": 0.2006,
+    "output": 0.2006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4-air-0111": {
+    "input": 0.1394,
+    "output": 0.1394,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4-airx": {
+    "input": 2.006,
+    "output": 2.006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4-flash": {
+    "input": 0.1003,
+    "output": 0.1003,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4-long": {
+    "input": 0.2006,
+    "output": 0.2006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4-plus": {
+    "input": 7.497,
+    "output": 7.497,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4-plus-0111": {
+    "input": 9.996,
+    "output": 9.996,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4.1v-thinking-flash": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4.1v-thinking-flashx": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4.5-air-derestricted": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4.5-air-derestricted-iceblink": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4.5-air-derestricted-iceblink-reextract": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4.5-air-derestricted-iceblink-v2": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4.5-air-derestricted-iceblink-v2-reextract": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4.5-air-derestricted-steam": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4.5-air-derestricted-steam-reextract": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-4.6-derestricted-v5": {
+    "input": 0.4,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-z1-air": {
+    "input": 0.07,
+    "output": 0.07,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-z1-airx": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/glm-zero-preview": {
+    "input": 1.802,
+    "output": 1.802,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/google/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/google/gemini-3-flash-preview-thinking": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/google/gemini-flash-1.5": {
+    "input": 0.0748,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/grok-3-beta": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/grok-3-fast-beta": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/grok-3-mini-beta": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/grok-3-mini-fast-beta": {
+    "input": 0.6,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/gryphe/mythomax-l2-13b": {
+    "input": 0.1003,
+    "output": 0.1003,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/huihui-ai/deepseek-r1-distill-llama-70b-abliterated": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/huihui-ai/deepseek-r1-distill-qwen-32b-abliterated": {
+    "input": 1.4,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/huihui-ai/llama-3.1-nemotron-70b-instruct-hf-abliterated": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/huihui-ai/llama-3.3-70b-instruct-abliterated": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/huihui-ai/qwen2.5-32b-instruct-abliterated": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/hunyuan-t1-latest": {
+    "input": 0.17,
+    "output": 0.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/hunyuan-turbos-20250226": {
+    "input": 0.187,
+    "output": 0.374,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/infermatic/mn-12b-inferor-v0.0": {
+    "input": 0.255,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/inflatebot/mn-12b-mag-mell-r1": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/inflection/inflection-3-pi": {
+    "input": 2.499,
+    "output": 9.996,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/inflection/inflection-3-productivity": {
+    "input": 2.499,
+    "output": 9.996,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/jamba-large": {
+    "input": 1.989,
+    "output": 7.99,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/jamba-large-1.6": {
+    "input": 1.989,
+    "output": 7.99,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/jamba-large-1.7": {
+    "input": 1.989,
+    "output": 7.99,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/jamba-mini": {
+    "input": 0.1989,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/jamba-mini-1.6": {
+    "input": 0.1989,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/jamba-mini-1.7": {
+    "input": 0.1989,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/kat-coder-air-v1": {
+    "input": 0.1,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/kat-coder-exp-72b-1010": {
+    "input": 0.1,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/kat-coder-pro-v1": {
+    "input": 1.5,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/kimi-k2-instruct-fast": {
+    "input": 0.1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/kimi-thinking-preview": {
+    "input": 31.46,
+    "output": 31.46,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/latitudegames/wayfarer-large-70b-llama-3.3": {
+    "input": 0.700000007,
+    "output": 0.700000007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/learnlm-1.5-pro-experimental": {
+    "input": 3.502,
+    "output": 10.506,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3+(3.1v3.3)-70b-hanami-x1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3+(3.1v3.3)-70b-new-dawn-v1.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3+(3v3.3)-70b-tenyxchat-daybreakstorywriter": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-anthrobomination": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-argunaut-1-sft": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-arliai-rpmax-v1.4": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-arliai-rpmax-v2": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-arliai-rpmax-v3": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-aurora-borealis": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-bigger-body": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-cirrus-x1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-cu-mai-r1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-damascus-r1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-dark-ages-v0.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-electra-r1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-electranova-v1.0": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-fallen-r1-v1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-fallen-v1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-forgotten-abomination-v5.0": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-forgotten-safeword-3.6": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-geneticlemonade-opus": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-geneticlemonade-unleashed-v3": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-ignition-v0.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-incandescent-malevolence": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-legion-v2.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-magnum-v4-se": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-magnum-v4-se-cirrus-x1-slerp": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-mhnnn-x1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-miraifanfare": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-mokume-gane-r1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-ms-nevoria": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-nova": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-predatorial-extasy": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-progenitor-v3.3": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-rawmaw": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-sapphira-0.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-sapphira-0.2": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-shakudo": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-strawberrylemonade-v1.0": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-strawberrylemonade-v1.2": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-the-omega-directive-unslop-v2.0": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-the-omega-directive-unslop-v2.1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llama-3.3-70b-vulpecula-r1": {
+    "input": 0.306,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/llm360/k2-think": {
+    "input": 0.17,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/magistral-small-2506": {
+    "input": 0.4,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/marinaraspaghetti/nemomix-unleashed-12b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/meganova-ai/manta-flash-1.0": {
+    "input": 0.02,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/meganova-ai/manta-mini-1.0": {
+    "input": 0.02,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/meganova-ai/manta-pro-1.0": {
+    "input": 0.06,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/meituan-longcat/longcat-flash-chat-fp8": {
+    "input": 0.15,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mercury-coder-small": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/meta-llama-3-1-8b-instruct-fp8": {
+    "input": 0.02,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/meta-llama/llama-3.1-8b-instruct": {
+    "input": 0.0544,
+    "output": 0.0544,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/meta-llama/llama-3.2-3b-instruct": {
+    "input": 0.0306,
+    "output": 0.0493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/meta-llama/llama-3.2-90b-vision-instruct": {
+    "input": 0.901,
+    "output": 0.901,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/meta-llama/llama-3.3-70b-instruct": {
+    "input": 0.05,
+    "output": 0.23,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/meta-llama/llama-4-maverick": {
+    "input": 0.18,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/meta-llama/llama-4-scout": {
+    "input": 0.085,
+    "output": 0.46,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/microsoft/mai-ds-r1-fp8": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/microsoft/wizardlm-2-8x22b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/minimax-m1": {
+    "input": 0.1394,
+    "output": 1.3328,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/minimax-m2": {
+    "input": 0.17,
+    "output": 1.53,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/minimax/minimax-01": {
+    "input": 0.1394,
+    "output": 1.122,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/minimax/minimax-m2-her": {
+    "input": 0.302,
+    "output": 1.207,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/minimax/minimax-m2.1": {
+    "input": 0.33,
+    "output": 1.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/minimax/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/minimax/minimax-m2.7": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/minimaxai/minimax-m1-80k": {
+    "input": 0.6052,
+    "output": 2.4225,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/miromind-ai/mirothinker-v1.5-235b": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistral-nemo-12b-instruct-2407": {
+    "input": 0.01,
+    "output": 0.01,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistral-small-31-24b-instruct": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/codestral-2508": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/devstral-2-123b-instruct-2512": {
+    "input": 0.4,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/devstral-small-2505": {
+    "input": 0.06,
+    "output": 0.06,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/ministral-14b-2512": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/ministral-14b-instruct-2512": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/ministral-3b-2512": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/ministral-8b-2512": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/mistral-7b-instruct": {
+    "input": 0.0544,
+    "output": 0.0544,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/mistral-large": {
+    "input": 2.006,
+    "output": 6.001,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/mistral-large-3-675b-instruct-2512": {
     "input": 1,
     "output": 3,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "nousresearch/hermes-4-70b": {
-    "input": 0.13,
+  "nano-gpt/mistralai/mistral-medium-3": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/mistral-medium-3.1": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/mistral-nemo-instruct-2407": {
+    "input": 0.1003,
+    "output": 0.1207,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/mistral-saba": {
+    "input": 0.1989,
+    "output": 0.595,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/mistral-small-creative": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/mistral-tiny": {
+    "input": 0.255,
+    "output": 0.255,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/mixtral-8x22b-instruct-v0.1": {
+    "input": 0.9,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mistralai/mixtral-8x7b-instruct-v0.1": {
+    "input": 0.27,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/mlabonne/neuraldaredevil-8b-abliterated": {
+    "input": 0.44,
+    "output": 0.44,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/moonshotai/kimi-dev-72b": {
+    "input": 0.4,
     "output": 0.4,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "nvidia/nemotron-3-nano-30b-a3b:free": {
+  "nano-gpt/moonshotai/kimi-k2-instruct": {
+    "input": 0.1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/moonshotai/kimi-k2-instruct-0711": {
+    "input": 0.1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/moonshotai/kimi-k2-instruct-0905": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/moonshotai/kimi-k2-thinking": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/moonshotai/kimi-k2-thinking-original": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/moonshotai/kimi-k2-thinking-turbo-original": {
+    "input": 1.15,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/moonshotai/kimi-k2.5": {
+    "input": 0.3,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/moonshotai/kimi-k2.5:thinking": {
+    "input": 0.3,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/neversleep/llama-3-lumimaid-70b-v0.1": {
+    "input": 2.006,
+    "output": 2.006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/neversleep/lumimaid-v0.2-70b": {
+    "input": 1,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nex-agi/deepseek-v3.1-nex-n1": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nothingiisreal/l3.1-70b-celeste-v0.1-bf16": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nousresearch 2/deephermes-3-mistral-24b-preview": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nousresearch 2/hermes-3-llama-3.1-70b": {
+    "input": 0.408,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nousresearch 2/hermes-4-405b": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nousresearch 2/hermes-4-405b:thinking": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nousresearch 2/hermes-4-70b": {
+    "input": 0.2006,
+    "output": 0.3995,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nousresearch 2/hermes-4-70b:thinking": {
+    "input": 0.2006,
+    "output": 0.3995,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nvidia/llama-3.1-nemotron-70b-instruct-hf": {
+    "input": 0.357,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nvidia/llama-3.1-nemotron-ultra-253b-v1": {
+    "input": 0.4,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nvidia/llama-3.3-nemotron-super-49b-v1": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nvidia/llama-3_3-nemotron-super-49b-v1_5": {
+    "input": 0.05,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nvidia/nemotron-3-nano-30b-a3b": {
+    "input": 0.17,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/nvidia/nvidia-nemotron-nano-9b-v2": {
+    "input": 0.17,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/chatgpt-4o-latest": {
+    "input": 4.998,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-3.5-turbo": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-4-turbo": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-4-turbo-preview": {
+    "input": 9.996,
+    "output": 30.005,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-4o": {
+    "input": 2.499,
+    "output": 9.996,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-4o-2024-08-06": {
+    "input": 2.499,
+    "output": 9.996,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-4o-2024-11-20": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-4o-mini": {
+    "input": 0.1496,
+    "output": 0.595,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-4o-mini-search-preview": {
+    "input": 0.088,
+    "output": 0.35,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-4o-search-preview": {
+    "input": 1.47,
+    "output": 5.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5-chat-latest": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5-codex": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5-pro": {
+    "input": 15,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5.1-2025-11-13": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5.1-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5.1-chat-latest": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5.1-codex-max": {
+    "input": 2.5,
+    "output": 20,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5.2-chat": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-5.2-pro": {
+    "input": 21,
+    "output": 168,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-oss-120b": {
+    "input": 0.05,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-oss-20b": {
+    "input": 0.04,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/gpt-oss-safeguard-20b": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o1": {
+    "input": 14.994,
+    "output": 59.993,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o1-preview": {
+    "input": 14.994,
+    "output": 59.993,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o1-pro": {
+    "input": 150,
+    "output": 600,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o3": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o3-deep-research": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o3-mini-high": {
+    "input": 0.64,
+    "output": 2.588,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o3-mini-low": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o3-pro-2025-06-10": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o4-mini-deep-research": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/openai/o4-mini-high": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/pamanseau/openreasoning-nemotron-32b": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/phi-4-mini-instruct": {
+    "input": 0.17,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/phi-4-multimodal-instruct": {
+    "input": 0.07,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qvq-max": {
+    "input": 1.4,
+    "output": 5.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen-long": {
+    "input": 0.1003,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen-max": {
+    "input": 1.5997,
+    "output": 6.392,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen-plus": {
+    "input": 0.3995,
+    "output": 1.2002,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen-turbo": {
+    "input": 0.04998,
+    "output": 0.2006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen/qwen3.5-397b-a17b": {
+    "input": 0.6,
+    "output": 3.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen2.5-32b-eva-v0.2": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen25-vl-72b-instruct": {
+    "input": 0.69989,
+    "output": 0.69989,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen3-30b-a3b-instruct-2507": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen3-max-2026-01-23": {
+    "input": 1.2002,
+    "output": 6.001,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen3-vl-235b-a22b-instruct-original": {
+    "input": 0.5,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwen3-vl-235b-a22b-thinking": {
+    "input": 0.5,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwq-32b": {
+    "input": 0.25599999,
+    "output": 0.30499999,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/qwq-32b-arliai-rpr-v1": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/raifle/sorcererlm-8x22b": {
+    "input": 4.505,
+    "output": 4.505,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/readyart/ms3.2-the-omega-directive-24b-unslop-v2.0": {
+    "input": 0.5,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/readyart/the-omega-abomination-l-70b-v1.0": {
+    "input": 0.7,
+    "output": 0.95,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/salesforce/llama-xlam-2-70b-fc-r": {
+    "input": 2.5,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/sao10k/l3-8b-stheno-v3.2": {
+    "input": 0.2006,
+    "output": 0.2006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/sao10k/l3.1-70b-euryale-v2.2": {
+    "input": 0.306,
+    "output": 0.357,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/sao10k/l3.1-70b-hanami-x1": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/sao10k/l3.3-70b-euryale-v2.3": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/sarvan-medium": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/shisa-ai/shisa-v2-llama3.3-70b": {
+    "input": 0.5,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/shisa-ai/shisa-v2.1-llama3.3-70b": {
+    "input": 0.5,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/sonar": {
+    "input": 1.003,
+    "output": 1.003,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/sonar-deep-research": {
+    "input": 3.4,
+    "output": 13.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/sonar-pro": {
+    "input": 2.992,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/sonar-reasoning-pro": {
+    "input": 2.006,
+    "output": 7.9985,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/soob3123/amoral-gemma3-27b-v2": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/soob3123/grayline-qwen3-8b": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/soob3123/veiled-calla-12b": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/steelskull/l3.3-cu-mai-r1-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/steelskull/l3.3-electra-r1-70b": {
+    "input": 0.69989,
+    "output": 0.69989,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/steelskull/l3.3-ms-evalebis-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/steelskull/l3.3-ms-evayale-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/steelskull/l3.3-ms-nevoria-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/steelskull/l3.3-nevoria-r1-70b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/step-2-16k-exp": {
+    "input": 7.004,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/step-2-mini": {
+    "input": 0.2006,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/step-3": {
+    "input": 0.2499,
+    "output": 0.6494,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/step-r1-v-mini": {
+    "input": 2.5,
+    "output": 11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/stepfun-ai/step-3.5-flash": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/stepfun-ai/step-3.5-flash:thinking": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/study_gpt-chatgpt-4o-latest": {
+    "input": 4.998,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/deepseek-r1-0528": {
+    "input": 2,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/deepseek-v3.1": {
+    "input": 1,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/deepseek-v3.2": {
+    "input": 0.5,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/gemma-3-27b-it": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/glm-4.6": {
+    "input": 0.75,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/glm-4.7": {
+    "input": 0.85,
+    "output": 3.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/glm-4.7-flash": {
+    "input": 0.15,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/glm-5": {
+    "input": 1.2,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/gpt-oss-120b": {
+    "input": 2,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/gpt-oss-20b": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/kimi-k2-thinking": {
+    "input": 2,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/kimi-k2.5": {
+    "input": 0.3,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/kimi-k2.5-thinking": {
+    "input": 0.3,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/llama3-3-70b": {
+    "input": 2,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/qwen2.5-vl-72b-instruct": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/qwen3-30b-a3b-instruct-2507": {
+    "input": 0.15,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/qwen3-coder": {
+    "input": 1.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tee/qwen3.5-397b-a17b": {
+    "input": 0.6,
+    "output": 3.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tencent/hunyuan-mt-7b": {
+    "input": 10,
+    "output": 20,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thedrummer 2/anubis-70b-v1": {
+    "input": 0.31,
+    "output": 0.31,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thedrummer 2/anubis-70b-v1.1": {
+    "input": 0.31,
+    "output": 0.31,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thedrummer 2/cydonia-24b-v2": {
+    "input": 0.1003,
+    "output": 0.1207,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thedrummer 2/cydonia-24b-v4": {
+    "input": 0.2006,
+    "output": 0.2414,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thedrummer 2/cydonia-24b-v4.1": {
+    "input": 0.1003,
+    "output": 0.1207,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thedrummer 2/cydonia-24b-v4.3": {
+    "input": 0.1003,
+    "output": 0.1207,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thedrummer 2/magidonia-24b-v4.3": {
+    "input": 0.1003,
+    "output": 0.1207,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thedrummer 2/rocinante-12b-v1.1": {
+    "input": 0.408,
+    "output": 0.595,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thedrummer 2/skyfall-36b-v2": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thedrummer 2/unslopnemo-12b-v4.1": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thudm/glm-4-32b-0414": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thudm/glm-4-9b-0414": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thudm/glm-z1-32b-0414": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thudm/glm-z1-9b-0414": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/thudm/glm-z1-rumination-32b-0414": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tngtech/deepseek-tng-r1t2-chimera": {
+    "input": 0.31,
+    "output": 0.31,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tngtech/tng-r1t-chimera": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/tongyi-zhiwen/qwenlong-l1-32b": {
+    "input": 0.14,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/undi95/remm-slerp-l2-13b": {
+    "input": 0.799,
+    "output": 1.207,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/universal-summarizer": {
+    "input": 30,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/unsloth/gemma-3-12b-it": {
+    "input": 0.272,
+    "output": 0.272,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/unsloth/gemma-3-1b-it": {
+    "input": 0.1003,
+    "output": 0.1003,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/unsloth/gemma-3-27b-it": {
+    "input": 0.2992,
+    "output": 0.2992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/unsloth/gemma-3-4b-it": {
+    "input": 0.2006,
+    "output": 0.2006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/v0-1.0-md": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/v0-1.5-lg": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/v0-1.5-md": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/venice-uncensored": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/venice-uncensored:web": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/vongolachouko/starcannon-unleashed-12b-v1.0": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/x-ai/grok-4-07-09": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/x-ai/grok-4-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/x-ai/grok-4-fast:thinking": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/x-ai/grok-4.1-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/x-ai/grok-4.1-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/x-ai/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/xiaomi/mimo-v2-flash": {
+    "input": 0.102,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/xiaomi/mimo-v2-flash-original": {
+    "input": 0.102,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/xiaomi/mimo-v2-flash-thinking": {
+    "input": 0.102,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/xiaomi/mimo-v2-flash-thinking-original": {
+    "input": 0.102,
+    "output": 0.306,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/yi-large": {
+    "input": 3.196,
+    "output": 3.196,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/yi-lightning": {
+    "input": 0.2006,
+    "output": 0.2006,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/yi-medium-200k": {
+    "input": 2.499,
+    "output": 2.499,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/z-ai/glm-4.5v": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/z-ai/glm-4.5v:thinking": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/z-ai/glm-4.6": {
+    "input": 0.4,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/z-ai/glm-4.6:thinking": {
+    "input": 0.4,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/zai-org/glm-4.7": {
+    "input": 0.15,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/zai-org/glm-4.7-flash": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/zai-org/glm-5": {
+    "input": 0.3,
+    "output": 2.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/zai-org/glm-5.1": {
+    "input": 0.3,
+    "output": 2.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/zai-org/glm-5.1:thinking": {
+    "input": 0.3,
+    "output": 2.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nano-gpt/zai-org/glm-5:thinking": {
+    "input": 0.3,
+    "output": 2.55,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nebius/baai/bge-en-icl": {
+    "input": 0.01,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nebius/baai/bge-multilingual-gemma2": {
+    "input": 0.01,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nebius/black-forest-labs/flux-dev": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "nvidia/nemotron-nano-12b-v2-vl:free": {
+  "nebius/black-forest-labs/flux-schnell": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "nvidia/nemotron-nano-9b-v2": {
+  "nebius/deepseek-ai/deepseek-r1-0528": {
+    "input": 0.8,
+    "output": 2.4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "nebius/deepseek-ai/deepseek-r1-0528-fast": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nebius/deepseek-ai/deepseek-v3-0324": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0.1875,
+    "cacheRead": 0.05
+  },
+  "nebius/deepseek-ai/deepseek-v3-0324-fast": {
+    "input": 0.75,
+    "output": 2.25,
+    "cacheWrite": 0.28125,
+    "cacheRead": 0.075
+  },
+  "nebius/deepseek-ai/deepseek-v3.2": {
+    "input": 0.3,
+    "output": 0.45,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.03
+  },
+  "nebius/google/gemma-2-2b-it": {
+    "input": 0.02,
+    "output": 0.06,
+    "cacheWrite": 0.025,
+    "cacheRead": 0.002
+  },
+  "nebius/google/gemma-2-9b-it-fast": {
+    "input": 0.03,
+    "output": 0.09,
+    "cacheWrite": 0.0375,
+    "cacheRead": 0.003
+  },
+  "nebius/google/gemma-3-27b-it": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0.125,
+    "cacheRead": 0.01
+  },
+  "nebius/google/gemma-3-27b-it-fast": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0.25,
+    "cacheRead": 0.02
+  },
+  "nebius/intfloat/e5-mistral-7b-instruct": {
+    "input": 0.01,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nebius/meta-llama/llama-3.3-70b-instruct": {
+    "input": 0.13,
+    "output": 0.4,
+    "cacheWrite": 0.16,
+    "cacheRead": 0.013
+  },
+  "nebius/meta-llama/llama-3.3-70b-instruct-fast": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0.31,
+    "cacheRead": 0.025
+  },
+  "nebius/meta-llama/llama-guard-3-8b": {
+    "input": 0.02,
+    "output": 0.06,
+    "cacheWrite": 0.025,
+    "cacheRead": 0.002
+  },
+  "nebius/meta-llama/meta-llama-3.1-8b-instruct": {
+    "input": 0.02,
+    "output": 0.06,
+    "cacheWrite": 0.025,
+    "cacheRead": 0.002
+  },
+  "nebius/meta-llama/meta-llama-3.1-8b-instruct-fast": {
+    "input": 0.03,
+    "output": 0.09,
+    "cacheWrite": 0.03,
+    "cacheRead": 0.003
+  },
+  "nebius/minimaxai/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.03
+  },
+  "nebius/moonshotai/kimi-k2-instruct": {
+    "input": 0.5,
+    "output": 2.4,
+    "cacheWrite": 0.625,
+    "cacheRead": 0.05
+  },
+  "nebius/moonshotai/kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0.75,
+    "cacheRead": 0.06
+  },
+  "nebius/moonshotai/kimi-k2.5": {
+    "input": 0.5,
+    "output": 2.5,
+    "cacheWrite": 0.625,
+    "cacheRead": 0.05
+  },
+  "nebius/moonshotai/kimi-k2.5-fast": {
+    "input": 0.5,
+    "output": 2.5,
+    "cacheWrite": 0.625,
+    "cacheRead": 0.05
+  },
+  "nebius/nousresearch/hermes-4-405b": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "nebius/nousresearch/hermes-4-70b": {
+    "input": 0.13,
+    "output": 0.4,
+    "cacheWrite": 0.16,
+    "cacheRead": 0.013
+  },
+  "nebius/nvidia/llama-3_1-nemotron-ultra-253b-v1": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0.75,
+    "cacheRead": 0.06
+  },
+  "nebius/nvidia/nemotron-3-super-120b-a12b": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nebius/nvidia/nemotron-nano-v2-12b": {
+    "input": 0.07,
+    "output": 0.2,
+    "cacheWrite": 0.08,
+    "cacheRead": 0.007
+  },
+  "nebius/nvidia/nvidia-nemotron-3-nano-30b-a3b": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0.075,
+    "cacheRead": 0.006
+  },
+  "nebius/openai/gpt-oss-120b": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0.18,
+    "cacheRead": 0.015
+  },
+  "nebius/openai/gpt-oss-20b": {
+    "input": 0.05,
+    "output": 0.2,
+    "cacheWrite": 0.06,
+    "cacheRead": 0.005
+  },
+  "nebius/primeintellect/intellect-3": {
+    "input": 0.2,
+    "output": 1.1,
+    "cacheWrite": 0.25,
+    "cacheRead": 0.02
+  },
+  "nebius/qwen/qwen2.5-coder-7b-fast": {
+    "input": 0.03,
+    "output": 0.09,
+    "cacheWrite": 0.03,
+    "cacheRead": 0.003
+  },
+  "nebius/qwen/qwen2.5-vl-72b-instruct": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0.31,
+    "cacheRead": 0.025
+  },
+  "nebius/qwen/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nebius/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nebius/qwen/qwen3-30b-a3b-instruct-2507": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0.125,
+    "cacheRead": 0.01
+  },
+  "nebius/qwen/qwen3-30b-a3b-thinking-2507": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0.125,
+    "cacheRead": 0.01
+  },
+  "nebius/qwen/qwen3-32b": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0.125,
+    "cacheRead": 0.01
+  },
+  "nebius/qwen/qwen3-32b-fast": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0.25,
+    "cacheRead": 0.02
+  },
+  "nebius/qwen/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0.125,
+    "cacheRead": 0.01
+  },
+  "nebius/qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.4,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nebius/qwen/qwen3-embedding-8b": {
+    "input": 0.01,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nebius/qwen/qwen3-next-80b-a3b-thinking": {
+    "input": 0.15,
+    "output": 1.2,
+    "cacheWrite": 0.18,
+    "cacheRead": 0.015
+  },
+  "nebius/zai-org/glm-4.5": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0.75,
+    "cacheRead": 0.06
+  },
+  "nebius/zai-org/glm-4.5-air": {
+    "input": 0.2,
+    "output": 1.2,
+    "cacheWrite": 0.25,
+    "cacheRead": 0.02
+  },
+  "nebius/zai-org/glm-4.7-fp8": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0.5,
+    "cacheRead": 0.04
+  },
+  "nebius/zai-org/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 1,
+    "cacheRead": 0.1
+  },
+  "nemomix-unleashed-12b": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nemoretriever-ocr-v1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nemotron-120b-a12b": {
+    "input": 0.3,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nemotron-3-120b-a12b": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nemotron-3-nano-30b-a3b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nemotron-3-super-120b-a12b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nemotron-3-super-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nemotron-4-340b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nemotron-nano-12b-v2-vl": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nemotron-nano-12b-v2-vl:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nemotron-nano-9b-v2": {
     "input": 0.04,
     "output": 0.16,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "nvidia/nemotron-nano-9b-v2:free": {
+  "nemotron-nano-9b-v2:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nemotron-nano-v2-12b": {
+    "input": 0.07,
+    "output": 0.2,
+    "cacheWrite": 0.08,
+    "cacheRead": 0.007
+  },
+  "neuraldaredevil-8b-abliterated": {
+    "input": 0.44,
+    "output": 0.44,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nova-2-lite": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nova-2-pro-v1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nova-3": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nova-lite": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0.015
+  },
+  "nova-micro": {
+    "input": 0.035,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0.00875
+  },
+  "nova-premier-v1": {
+    "input": 2.5,
+    "output": 12.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nova-pro": {
+    "input": 0.8,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "nova/nova-2-lite-v1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nova/nova-2-pro-v1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/baichuan/baichuan-m2-32b": {
+    "input": 0.07,
+    "output": 0.07,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/baidu/ernie-4.5-21b-a3b": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/baidu/ernie-4.5-21b-a3b-thinking": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/baidu/ernie-4.5-300b-a47b-paddle": {
+    "input": 0.28,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/baidu/ernie-4.5-vl-28b-a3b": {
+    "input": 1.4,
+    "output": 5.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/baidu/ernie-4.5-vl-28b-a3b-thinking": {
+    "input": 0.39,
+    "output": 0.39,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/baidu/ernie-4.5-vl-424b-a47b": {
+    "input": 0.42,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/deepseek/deepseek-ocr": {
+    "input": 0.03,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/deepseek/deepseek-ocr-2": {
+    "input": 0.03,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/deepseek/deepseek-prover-v2-671b": {
+    "input": 0.7,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/deepseek/deepseek-r1-0528": {
+    "input": 0.7,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.35
+  },
+  "novita-ai/deepseek/deepseek-r1-0528-qwen3-8b": {
+    "input": 0.06,
+    "output": 0.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/deepseek/deepseek-r1-distill-llama-70b": {
+    "input": 0.8,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/deepseek/deepseek-r1-turbo": {
+    "input": 0.7,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/deepseek/deepseek-v3-0324": {
+    "input": 0.27,
+    "output": 1.12,
+    "cacheWrite": 0,
+    "cacheRead": 0.135
+  },
+  "novita-ai/deepseek/deepseek-v3-turbo": {
+    "input": 0.4,
+    "output": 1.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/deepseek/deepseek-v3.1": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0.135
+  },
+  "novita-ai/deepseek/deepseek-v3.1-terminus": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0.135
+  },
+  "novita-ai/deepseek/deepseek-v3.2": {
+    "input": 0.269,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.1345
+  },
+  "novita-ai/deepseek/deepseek-v3.2-exp": {
+    "input": 0.27,
+    "output": 0.41,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/google/gemma-3-27b-it": {
+    "input": 0.119,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/gryphe/mythomax-l2-13b": {
+    "input": 0.09,
+    "output": 0.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/kwaipilot/kat-coder": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/kwaipilot/kat-coder-pro": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "novita-ai/meta-llama/llama-3-70b-instruct": {
+    "input": 0.51,
+    "output": 0.74,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/meta-llama/llama-3-8b-instruct": {
+    "input": 0.04,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/meta-llama/llama-3.1-8b-instruct": {
+    "input": 0.02,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/meta-llama/llama-3.3-70b-instruct": {
+    "input": 0.135,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+    "input": 0.27,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/meta-llama/llama-4-scout-17b-16e-instruct": {
+    "input": 0.18,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/microsoft/wizardlm-2-8x22b": {
+    "input": 0.62,
+    "output": 0.62,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/minimax/minimax-m2": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "novita-ai/minimax/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "novita-ai/minimax/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "novita-ai/minimaxai/minimax-m1-80k": {
+    "input": 0.55,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/mistralai/mistral-nemo": {
+    "input": 0.04,
+    "output": 0.17,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/moonshotai/kimi-k2-0905": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/moonshotai/kimi-k2-instruct": {
+    "input": 0.57,
+    "output": 2.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/moonshotai/kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/moonshotai/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "novita-ai/nousresearch/hermes-2-pro-llama-3-8b": {
+    "input": 0.14,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/openai/gpt-oss-120b": {
+    "input": 0.05,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/openai/gpt-oss-20b": {
+    "input": 0.04,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/paddlepaddle/paddleocr-vl": {
+    "input": 0.02,
+    "output": 0.02,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen-2.5-72b-instruct": {
+    "input": 0.38,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen-mt-plus": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen2.5-7b-instruct": {
+    "input": 0.07,
+    "output": 0.07,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen2.5-vl-72b-instruct": {
+    "input": 0.8,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-235b-a22b-fp8": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.09,
+    "output": 0.58,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.3,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-30b-a3b-fp8": {
+    "input": 0.09,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-32b-fp8": {
+    "input": 0.1,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-4b-fp8": {
+    "input": 0.03,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-8b-fp8": {
+    "input": 0.035,
+    "output": 0.138,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.07,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.3,
+    "output": 1.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-coder-next": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-max": {
+    "input": 2.11,
+    "output": 8.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-next-80b-a3b-instruct": {
+    "input": 0.15,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-next-80b-a3b-thinking": {
+    "input": 0.15,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-omni-30b-a3b-instruct": {
+    "input": 0.25,
+    "output": 0.97,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-omni-30b-a3b-thinking": {
+    "input": 0.25,
+    "output": 0.97,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-vl-235b-a22b-instruct": {
+    "input": 0.3,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-vl-235b-a22b-thinking": {
+    "input": 0.98,
+    "output": 3.95,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-vl-30b-a3b-instruct": {
+    "input": 0.2,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-vl-30b-a3b-thinking": {
+    "input": 0.2,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3-vl-8b-instruct": {
+    "input": 0.08,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/qwen/qwen3.5-397b-a17b": {
+    "input": 0.6,
+    "output": 3.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/sao10k/l3-70b-euryale-v2.1": {
+    "input": 1.48,
+    "output": 1.48,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/sao10k/l3-8b-lunaris": {
+    "input": 0.05,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/sao10k/l3-8b-stheno-v3.2": {
+    "input": 0.05,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/sao10k/l31-70b-euryale-v2.2": {
+    "input": 1.48,
+    "output": 1.48,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/skywork/r1v4-lite": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/xiaomimimo/mimo-v2-flash": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "novita-ai/zai-org/autoglm-phone-9b-multilingual": {
+    "input": 0.035,
+    "output": 0.138,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/zai-org/glm-4.5": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "novita-ai/zai-org/glm-4.5-air": {
+    "input": 0.13,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "novita-ai/zai-org/glm-4.5v": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "novita-ai/zai-org/glm-4.6": {
+    "input": 0.55,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "novita-ai/zai-org/glm-4.6v": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0.055
+  },
+  "novita-ai/zai-org/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "novita-ai/zai-org/glm-4.7-flash": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "novita-ai/zai-org/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "nvidia-nemotron-3-nano-30b-a3b-bf16": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia-nemotron-3-super-120b-a12b-fp8": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia-nemotron-nano-9b-v2": {
+    "input": 0.17,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia.nemotron-nano-12b-v2": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia.nemotron-nano-3-30b": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia.nemotron-nano-9b-v2": {
+    "input": 0.06,
+    "output": 0.23,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia.nemotron-super-3-120b": {
+    "input": 0.15,
+    "output": 0.65,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/black-forest-labs/flux.1-dev": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/deepseek-ai/deepseek-coder-6.7b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/deepseek-ai/deepseek-r1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/deepseek-ai/deepseek-r1-0528": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/deepseek-ai/deepseek-v3.1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/deepseek-ai/deepseek-v3.1-terminus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/deepseek-ai/deepseek-v3.2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/google/codegemma-1.1-7b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/google/codegemma-7b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/google/gemma-2-27b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/google/gemma-2-2b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/google/gemma-3-12b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/google/gemma-3-1b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/google/gemma-3-27b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/google/gemma-3n-e2b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/google/gemma-3n-e4b-it": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/meta/codellama-70b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/meta/llama-3.1-405b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/meta/llama-3.1-70b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/meta/llama-3.2-11b-vision-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/meta/llama-3.2-1b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/meta/llama-3.3-70b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/meta/llama-4-maverick-17b-128e-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/meta/llama-4-scout-17b-16e-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/meta/llama3-70b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/meta/llama3-8b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/microsoft/phi-3-medium-128k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/microsoft/phi-3-medium-4k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/microsoft/phi-3-small-128k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/microsoft/phi-3-small-8k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/microsoft/phi-3-vision-128k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/microsoft/phi-3.5-moe-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/microsoft/phi-3.5-vision-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/microsoft/phi-4-mini-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/minimaxai/minimax-m2.1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/minimaxai/minimax-m2.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/mistralai/codestral-22b-instruct-v0.1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/mistralai/devstral-2-123b-instruct-2512": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/mistralai/mamba-codestral-7b-v0.1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/mistralai/ministral-14b-instruct-2512": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/mistralai/mistral-large-2-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/mistralai/mistral-large-3-675b-instruct-2512": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/mistralai/mistral-small-3.1-24b-instruct-2503": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/moonshotai/kimi-k2-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/moonshotai/kimi-k2-instruct-0905": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/moonshotai/kimi-k2-thinking": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/moonshotai/kimi-k2.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/cosmos-nemotron-34b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/llama-3.1-nemotron-51b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/llama-3.1-nemotron-70b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/llama-3.1-nemotron-ultra-253b-v1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/llama-3.3-nemotron-super-49b-v1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/llama-3.3-nemotron-super-49b-v1.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/llama-embed-nemotron-8b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/llama3-chatqa-1.5-70b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/nemoretriever-ocr-v1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/nemotron-3-nano-30b-a3b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/nemotron-3-super-120b-a12b": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/nemotron-4-340b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/nvidia-nemotron-nano-9b-v2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/nvidia/parakeet-tdt-0.6b-v2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/openai/gpt-oss-120b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/openai/whisper-large-v3": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/qwen/qwen2.5-coder-32b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/qwen/qwen2.5-coder-7b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/qwen/qwen3-235b-a22b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/qwen/qwen3-next-80b-a3b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/qwen/qwen3-next-80b-a3b-thinking": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/qwen/qwen3.5-397b-a17b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/qwen/qwq-32b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/stepfun-ai/step-3.5-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/z-ai/glm4.7": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "nvidia/z-ai/glm5": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
@@ -1379,9 +22469,21 @@
     "cacheWrite": 0,
     "cacheRead": 0.55
   },
+  "o3-mini-low": {
+    "input": 9.996,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "o3-pro": {
     "input": 20,
     "output": 80,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "o3-pro-2025-06-10": {
+    "input": 9.996,
+    "output": 19.992,
     "cacheWrite": 0,
     "cacheRead": 0
   },
@@ -1397,11 +22499,167 @@
     "cacheWrite": 0,
     "cacheRead": 0.5
   },
+  "o4-mini-high": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "olafangensan-glm-4.7-flash-heretic": {
+    "input": 0.14,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "olmo-2-0325-32b-instruct": {
+    "input": 0.05,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "olmo-3-7b-instruct": {
+    "input": 0.1,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "olmo-3-7b-think": {
+    "input": 0.12,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "olmo-3.1-32b-instruct": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "olmo-3.1-32b-think": {
+    "input": 0.15,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "open-mistral-7b": {
+    "input": 0.25,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "open-mixtral-8x22b": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "open-mixtral-8x7b": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai-gpt-4o-2024-11-20": {
+    "input": 3.125,
+    "output": 12.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai-gpt-4o-mini-2024-07-18": {
+    "input": 0.1875,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.09375
+  },
+  "openai-gpt-52": {
+    "input": 2.19,
+    "output": 17.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.219
+  },
+  "openai-gpt-52-codex": {
+    "input": 2.19,
+    "output": 17.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.219
+  },
+  "openai-gpt-53-codex": {
+    "input": 2.19,
+    "output": 17.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.219
+  },
+  "openai-gpt-54": {
+    "input": 3.13,
+    "output": 18.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.313
+  },
+  "openai-gpt-54-mini": {
+    "input": 0.9375,
+    "output": 5.625,
+    "cacheWrite": 0,
+    "cacheRead": 0.09375
+  },
+  "openai-gpt-54-pro": {
+    "input": 37.5,
+    "output": 225,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai-gpt-oss-120b": {
+    "input": 0.07,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai.gpt-oss-120b-1:0": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai.gpt-oss-20b-1:0": {
+    "input": 0.07,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai.gpt-oss-safeguard-120b": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai.gpt-oss-safeguard-20b": {
+    "input": 0.07,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai/codex-mini-latest": {
+    "input": 1.5,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.375
+  },
   "openai/gpt-3.5-turbo": {
     "input": 0.5,
     "output": 1.5,
     "cacheWrite": 0,
     "cacheRead": 1.25
+  },
+  "openai/gpt-4": {
+    "input": 30,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai/gpt-4-turbo": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
   },
   "openai/gpt-4.1": {
     "input": 2,
@@ -1415,7 +22673,31 @@
     "cacheWrite": 0,
     "cacheRead": 0.1
   },
+  "openai/gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
   "openai/gpt-4o": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "openai/gpt-4o-2024-05-13": {
+    "input": 5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai/gpt-4o-2024-08-06": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "openai/gpt-4o-2024-11-20": {
     "input": 2.5,
     "output": 10,
     "cacheWrite": 0,
@@ -1433,7 +22715,7 @@
     "cacheWrite": 0,
     "cacheRead": 0.125
   },
-  "openai/gpt-5-chat": {
+  "openai/gpt-5-chat-latest": {
     "input": 1.25,
     "output": 10,
     "cacheWrite": 0,
@@ -1444,12 +22726,6 @@
     "output": 10,
     "cacheWrite": 0,
     "cacheRead": 0.125
-  },
-  "openai/gpt-5-image": {
-    "input": 5,
-    "output": 10,
-    "cacheWrite": 0,
-    "cacheRead": 1.25
   },
   "openai/gpt-5-mini": {
     "input": 0.25,
@@ -1473,9 +22749,9 @@
     "input": 1.25,
     "output": 10,
     "cacheWrite": 0,
-    "cacheRead": 0.125
+    "cacheRead": 0.13
   },
-  "openai/gpt-5.1-chat": {
+  "openai/gpt-5.1-chat-latest": {
     "input": 1.25,
     "output": 10,
     "cacheWrite": 0,
@@ -1488,10 +22764,10 @@
     "cacheRead": 0.125
   },
   "openai/gpt-5.1-codex-max": {
-    "input": 1.1,
-    "output": 9,
+    "input": 1.25,
+    "output": 10,
     "cacheWrite": 0,
-    "cacheRead": 0.11
+    "cacheRead": 0.125
   },
   "openai/gpt-5.1-codex-mini": {
     "input": 0.25,
@@ -1505,7 +22781,7 @@
     "cacheWrite": 0,
     "cacheRead": 0.175
   },
-  "openai/gpt-5.2-chat": {
+  "openai/gpt-5.2-chat-latest": {
     "input": 1.75,
     "output": 14,
     "cacheWrite": 0,
@@ -1523,39 +22799,93 @@
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "openai/gpt-oss-120b": {
-    "input": 0.072,
-    "output": 0.28,
+  "openai/gpt-5.3-chat-latest": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "openai/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "openai/gpt-5.3-codex-spark": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "openai/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "openai/gpt-5.4-mini": {
+    "input": 0.75,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "openai/gpt-5.4-nano": {
+    "input": 0.2,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "openai/gpt-5.4-pro": {
+    "input": 30,
+    "output": 180,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "openai/gpt-oss-120b:exacto": {
-    "input": 0.05,
-    "output": 0.24,
+  "openai/o1": {
+    "input": 15,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 7.5
+  },
+  "openai/o1-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "openai/o1-preview": {
+    "input": 15,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 7.5
+  },
+  "openai/o1-pro": {
+    "input": 150,
+    "output": 600,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "openai/gpt-oss-120b:free": {
-    "input": 0,
-    "output": 0,
+  "openai/o3": {
+    "input": 2,
+    "output": 8,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 0.5
   },
-  "openai/gpt-oss-20b": {
-    "input": 0.05,
-    "output": 0.2,
+  "openai/o3-deep-research": {
+    "input": 10,
+    "output": 40,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 2.5
   },
-  "openai/gpt-oss-20b:free": {
-    "input": 0,
-    "output": 0,
+  "openai/o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 0.55
   },
-  "openai/gpt-oss-safeguard-20b": {
-    "input": 0.075,
-    "output": 0.3,
+  "openai/o3-pro": {
+    "input": 20,
+    "output": 80,
     "cacheWrite": 0,
     "cacheRead": 0
   },
@@ -1565,11 +22895,923 @@
     "cacheWrite": 0,
     "cacheRead": 0.28
   },
+  "openai/o4-mini-deep-research": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "openai/text-embedding-3-large": {
+    "input": 0.13,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai/text-embedding-3-small": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openai/text-embedding-ada-002": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode-go/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "opencode-go/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "opencode-go/mimo-v2-omni": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "opencode-go/mimo-v2-pro": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "opencode-go/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "opencode-go/minimax-m2.7": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "opencode/big-pickle": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/claude-3-5-haiku": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "opencode/claude-haiku-4-5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "opencode/claude-opus-4-1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "opencode/claude-opus-4-5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "opencode/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "opencode/claude-sonnet-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "opencode/claude-sonnet-4-5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "opencode/claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "opencode/gemini-3-flash": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "opencode/gemini-3-pro": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "opencode/gemini-3.1-pro": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "opencode/glm-4.6": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "opencode/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "opencode/glm-4.7-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "opencode/glm-5-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/gpt-5": {
+    "input": 1.07,
+    "output": 8.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.107
+  },
+  "opencode/gpt-5-codex": {
+    "input": 1.07,
+    "output": 8.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.107
+  },
+  "opencode/gpt-5-nano": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/gpt-5.1": {
+    "input": 1.07,
+    "output": 8.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.107
+  },
+  "opencode/gpt-5.1-codex": {
+    "input": 1.07,
+    "output": 8.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.107
+  },
+  "opencode/gpt-5.1-codex-max": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "opencode/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "opencode/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "opencode/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "opencode/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "opencode/gpt-5.3-codex-spark": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "opencode/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "opencode/gpt-5.4-mini": {
+    "input": 0.75,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "opencode/gpt-5.4-nano": {
+    "input": 0.2,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "opencode/gpt-5.4-pro": {
+    "input": 30,
+    "output": 180,
+    "cacheWrite": 0,
+    "cacheRead": 30
+  },
+  "opencode/grok-code": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/kimi-k2": {
+    "input": 0.4,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.4
+  },
+  "opencode/kimi-k2-thinking": {
+    "input": 0.4,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.4
+  },
+  "opencode/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "opencode/kimi-k2.5-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/mimo-v2-flash-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/mimo-v2-omni-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/mimo-v2-pro-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "opencode/minimax-m2.1-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "opencode/minimax-m2.5-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/nemotron-3-super-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/qwen3-coder": {
+    "input": 0.45,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/qwen3.6-plus-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "opencode/trinity-large-preview-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openreasoning-nemotron-32b": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/anthropic/claude-3.5-haiku": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "openrouter/anthropic/claude-3.7-sonnet": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "openrouter/anthropic/claude-haiku-4.5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "openrouter/anthropic/claude-opus-4": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "openrouter/anthropic/claude-opus-4.1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "openrouter/anthropic/claude-opus-4.5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "openrouter/anthropic/claude-opus-4.6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "openrouter/anthropic/claude-sonnet-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "openrouter/anthropic/claude-sonnet-4.5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "openrouter/anthropic/claude-sonnet-4.6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "openrouter/arcee-ai/trinity-large-preview:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/arcee-ai/trinity-mini:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/black-forest-labs/flux.2-flex": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/black-forest-labs/flux.2-klein-4b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/black-forest-labs/flux.2-max": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/black-forest-labs/flux.2-pro": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/bytedance-seed/seedream-4.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/cognitivecomputations/dolphin-mistral-24b-venice-edition:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/deepseek/deepseek-chat-v3-0324": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/deepseek/deepseek-chat-v3.1": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/deepseek/deepseek-r1-distill-llama-70b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/deepseek/deepseek-v3.1-terminus": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/deepseek/deepseek-v3.1-terminus:exacto": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/deepseek/deepseek-v3.2": {
+    "input": 0.28,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/deepseek/deepseek-v3.2-speciale": {
+    "input": 0.27,
+    "output": 0.41,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemini-2.0-flash-001": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "openrouter/google/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.0375
+  },
+  "openrouter/google/gemini-2.5-flash-lite": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "openrouter/google/gemini-2.5-flash-lite-preview-09-2025": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "openrouter/google/gemini-2.5-flash-preview-09-2025": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.031
+  },
+  "openrouter/google/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.31
+  },
+  "openrouter/google/gemini-2.5-pro-preview-05-06": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.31
+  },
+  "openrouter/google/gemini-2.5-pro-preview-06-05": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.31
+  },
+  "openrouter/google/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "openrouter/google/gemini-3-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemini-3.1-flash-lite-preview": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 0.083,
+    "cacheRead": 0.025
+  },
+  "openrouter/google/gemini-3.1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemini-3.1-pro-preview-customtools": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemma-2-9b-it": {
+    "input": 0.03,
+    "output": 0.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemma-3-12b-it": {
+    "input": 0.03,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemma-3-12b-it:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemma-3-27b-it": {
+    "input": 0.04,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemma-3-27b-it:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemma-3-4b-it": {
+    "input": 0.01703,
+    "output": 0.06815,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemma-3-4b-it:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemma-3n-e2b-it:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemma-3n-e4b-it": {
+    "input": 0.02,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/google/gemma-3n-e4b-it:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/inception/mercury": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "openrouter/inception/mercury-2": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "openrouter/inception/mercury-coder": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "openrouter/liquid/lfm-2.5-1.2b-instruct:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/liquid/lfm-2.5-1.2b-thinking:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/meta-llama/llama-3.2-11b-vision-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/meta-llama/llama-3.2-3b-instruct:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/meta-llama/llama-3.3-70b-instruct:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/minimax/minimax-01": {
+    "input": 0.2,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/minimax/minimax-m1": {
+    "input": 0.4,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/minimax/minimax-m2": {
+    "input": 0.28,
+    "output": 1.15,
+    "cacheWrite": 1.15,
+    "cacheRead": 0.28
+  },
+  "openrouter/minimax/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/minimax/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "openrouter/minimax/minimax-m2.7": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "openrouter/mistralai/codestral-2508": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/mistralai/devstral-2512": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/mistralai/devstral-medium-2507": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/mistralai/devstral-small-2505": {
+    "input": 0.06,
+    "output": 0.12,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/mistralai/devstral-small-2507": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/mistralai/mistral-medium-3": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/mistralai/mistral-medium-3.1": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/mistralai/mistral-small-2603": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/mistralai/mistral-small-3.1-24b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/mistralai/mistral-small-3.2-24b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/moonshotai/kimi-k2": {
+    "input": 0.55,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/moonshotai/kimi-k2-0905": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/moonshotai/kimi-k2-0905:exacto": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/moonshotai/kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "openrouter/moonshotai/kimi-k2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "openrouter/moonshotai/kimi-k2:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/nousresearch/hermes-3-llama-3.1-405b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/nousresearch/hermes-4-405b": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/nousresearch/hermes-4-70b": {
+    "input": 0.13,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/nvidia/nemotron-3-nano-30b-a3b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/nvidia/nemotron-3-super-120b-a12b": {
+    "input": 0.1,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/nvidia/nemotron-3-super-120b-a12b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/nvidia/nemotron-nano-12b-v2-vl:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/nvidia/nemotron-nano-9b-v2": {
+    "input": 0.04,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/nvidia/nemotron-nano-9b-v2:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/openai/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "openrouter/openai/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "openrouter/openai/gpt-4o-mini": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
   "openrouter/openai/gpt-5": {
     "input": 1.25,
     "output": 10,
     "cacheWrite": 0,
     "cacheRead": 0
+  },
+  "openrouter/openai/gpt-5-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/openai/gpt-5-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "openrouter/openai/gpt-5-image": {
+    "input": 5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
   },
   "openrouter/openai/gpt-5-mini": {
     "input": 0.25,
@@ -1583,7 +23825,187 @@
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "openrouter/pony-alpha": {
+  "openrouter/openai/gpt-5-pro": {
+    "input": 15,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/openai/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "openrouter/openai/gpt-5.1-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "openrouter/openai/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "openrouter/openai/gpt-5.1-codex-max": {
+    "input": 1.1,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "openrouter/openai/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "openrouter/openai/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "openrouter/openai/gpt-5.2-chat": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "openrouter/openai/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "openrouter/openai/gpt-5.2-pro": {
+    "input": 21,
+    "output": 168,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/openai/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "openrouter/openai/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "openrouter/openai/gpt-5.4-mini": {
+    "input": 7.5e-07,
+    "output": 4.5e-06,
+    "cacheWrite": 0,
+    "cacheRead": 7.5e-08
+  },
+  "openrouter/openai/gpt-5.4-nano": {
+    "input": 2e-07,
+    "output": 1.25e-06,
+    "cacheWrite": 0,
+    "cacheRead": 2e-08
+  },
+  "openrouter/openai/gpt-5.4-pro": {
+    "input": 30,
+    "output": 180,
+    "cacheWrite": 0,
+    "cacheRead": 30
+  },
+  "openrouter/openai/gpt-oss-120b": {
+    "input": 0.072,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/openai/gpt-oss-120b:exacto": {
+    "input": 0.05,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/openai/gpt-oss-120b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/openai/gpt-oss-20b": {
+    "input": 0.05,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/openai/gpt-oss-20b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/openai/gpt-oss-safeguard-20b": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/openai/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.28
+  },
+  "openrouter/openrouter/free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/prime-intellect/intellect-3": {
+    "input": 0.2,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen-2.5-coder-32b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen2.5-vl-72b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3-235b-a22b-07-25": {
+    "input": 0.15,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.078,
+    "output": 0.312,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3-30b-a3b-instruct-2507": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3-30b-a3b-thinking-2507": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3-4b:free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
@@ -1595,17 +24017,185 @@
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "openrouter/sherlock-dash-alpha": {
+  "openrouter/qwen/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.07,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3-coder-flash": {
+    "input": 0.3,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3-coder:exacto": {
+    "input": 0.38,
+    "output": 1.53,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3-coder:free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "openrouter/sherlock-think-alpha": {
+  "openrouter/qwen/qwen3-max": {
+    "input": 1.2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3-next-80b-a3b-instruct": {
+    "input": 0.14,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3-next-80b-a3b-instruct:free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3-next-80b-a3b-thinking": {
+    "input": 0.14,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3.5-397b-a17b": {
+    "input": 0.6,
+    "output": 3.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3.5-plus-02-15": {
+    "input": 0.4,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3.6-plus-preview:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/qwen/qwen3.6-plus:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/sourceful/riverflow-v2-fast-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/sourceful/riverflow-v2-max-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/sourceful/riverflow-v2-standard-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/stepfun/step-3.5-flash": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "openrouter/stepfun/step-3.5-flash:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/x-ai/grok-3": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 15,
+    "cacheRead": 0.75
+  },
+  "openrouter/x-ai/grok-3-beta": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 15,
+    "cacheRead": 0.75
+  },
+  "openrouter/x-ai/grok-3-mini": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0.5,
+    "cacheRead": 0.075
+  },
+  "openrouter/x-ai/grok-3-mini-beta": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0.5,
+    "cacheRead": 0.075
+  },
+  "openrouter/x-ai/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 15,
+    "cacheRead": 0.75
+  },
+  "openrouter/x-ai/grok-4-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0.05,
+    "cacheRead": 0.05
+  },
+  "openrouter/x-ai/grok-4.1-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0.05,
+    "cacheRead": 0.05
+  },
+  "openrouter/x-ai/grok-4.20-beta": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "openrouter/x-ai/grok-4.20-multi-agent-beta": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "openrouter/x-ai/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "openrouter/xiaomi/mimo-v2-flash": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "openrouter/xiaomi/mimo-v2-omni": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "openrouter/xiaomi/mimo-v2-pro": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
   },
   "openrouter/z-ai/glm-4.5": {
     "input": 0.6,
@@ -1619,200 +24209,3494 @@
     "cacheWrite": 0,
     "cacheRead": 0
   },
+  "openrouter/z-ai/glm-4.5-air:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "openrouter/z-ai/glm-4.5v": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
   "openrouter/z-ai/glm-4.6": {
     "input": 0.6,
     "output": 2.2,
     "cacheWrite": 0,
     "cacheRead": 0.11
   },
-  "qwen/qwen-2.5-coder-32b-instruct": {
-    "input": 0,
-    "output": 0,
+  "openrouter/z-ai/glm-4.6:exacto": {
+    "input": 0.6,
+    "output": 1.9,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 0.11
   },
-  "qwen/qwen-2.5-vl-7b-instruct:free": {
-    "input": 0,
-    "output": 0,
+  "openrouter/z-ai/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
     "cacheWrite": 0,
-    "cacheRead": 0
+    "cacheRead": 0.11
   },
-  "qwen/qwen2.5-vl-32b-instruct:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen2.5-vl-72b-instruct": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen2.5-vl-72b-instruct:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-14b:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-235b-a22b-07-25": {
-    "input": 0.15,
-    "output": 0.85,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-235b-a22b-07-25:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-235b-a22b-thinking-2507": {
-    "input": 0.078,
-    "output": 0.312,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-235b-a22b:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-30b-a3b-instruct-2507": {
-    "input": 0.2,
-    "output": 0.8,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-30b-a3b-thinking-2507": {
-    "input": 0.2,
-    "output": 0.8,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-30b-a3b:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-32b:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-4b:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-8b:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-coder": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "qwen/qwen3-coder-30b-a3b-instruct": {
+  "openrouter/z-ai/glm-4.7-flash": {
     "input": 0.07,
-    "output": 0.27,
+    "output": 0.4,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "qwen/qwen3-coder-flash": {
+  "openrouter/z-ai/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "openrouter/z-ai/glm-5-turbo": {
+    "input": 1.2,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "orpheus-arabic-saudi": {
+    "input": 40,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "orpheus-v1-english": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "osmosis-structure-0.6b": {
+    "input": 0.1,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/deepseek-r1-distill-llama-70b": {
+    "input": 0.74,
+    "output": 0.74,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/gpt-oss-120b": {
+    "input": 0.09,
+    "output": 0.47,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/gpt-oss-20b": {
+    "input": 0.05,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/llama-3.1-8b-instruct": {
+    "input": 0.11,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/meta-llama-3_3-70b-instruct": {
+    "input": 0.74,
+    "output": 0.74,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/mistral-7b-instruct-v0.3": {
+    "input": 0.11,
+    "output": 0.11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/mistral-nemo-instruct-2407": {
+    "input": 0.14,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/mistral-small-3.2-24b-instruct-2506": {
+    "input": 0.1,
+    "output": 0.31,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/mixtral-8x7b-instruct-v0.1": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/qwen2.5-coder-32b-instruct": {
+    "input": 0.96,
+    "output": 0.96,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/qwen2.5-vl-72b-instruct": {
+    "input": 1.01,
+    "output": 1.01,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/qwen3-32b": {
+    "input": 0.09,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ovhcloud/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.07,
+    "output": 0.26,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "paddleocr-vl": {
+    "input": 0.02,
+    "output": 0.02,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "paddleocr-vl-1.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "palmyra-x5": {
+    "input": 0.6,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "pangu-pro-moe": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "parakeet-tdt-0.6b-v2": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "perplexity-agent/anthropic/claude-haiku-4-5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "perplexity-agent/anthropic/claude-opus-4-5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "perplexity-agent/anthropic/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "perplexity-agent/anthropic/claude-sonnet-4-5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "perplexity-agent/anthropic/claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "perplexity-agent/google/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "perplexity-agent/google/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "perplexity-agent/google/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "perplexity-agent/google/gemini-3.1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "perplexity-agent/nvidia/nemotron-3-super-120b-a12b": {
+    "input": 0.25,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "perplexity-agent/openai/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "perplexity-agent/openai/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "perplexity-agent/openai/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "perplexity-agent/openai/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "perplexity-agent/perplexity/sonar": {
+    "input": 0.25,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.0625
+  },
+  "perplexity-agent/xai/grok-4-1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "perplexity/sonar": {
+    "input": 1,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "perplexity/sonar-deep-research": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "perplexity/sonar-pro": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "perplexity/sonar-reasoning-pro": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "phi-3-vision-128k-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "phi-3.5-vision-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "phi-4-mini": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "phi-4-multimodal": {
+    "input": 0.08,
+    "output": 0.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "phi-4-reasoning-plus": {
+    "input": 0.125,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "pixtral-12b": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "pixtral-12b-2409": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "pixtral-large": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "pixtral-large-2411": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "plamo-embedding-1b": {
+    "input": 0.019,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/anthropic/claude-haiku-3": {
+    "input": 0.21,
+    "output": 1.1,
+    "cacheWrite": 0.26,
+    "cacheRead": 0.021
+  },
+  "poe/anthropic/claude-haiku-3.5": {
+    "input": 0.68,
+    "output": 3.4,
+    "cacheWrite": 0.85,
+    "cacheRead": 0.068
+  },
+  "poe/anthropic/claude-haiku-4.5": {
+    "input": 0.85,
+    "output": 4.3,
+    "cacheWrite": 1.1,
+    "cacheRead": 0.085
+  },
+  "poe/anthropic/claude-opus-4": {
+    "input": 13,
+    "output": 64,
+    "cacheWrite": 16,
+    "cacheRead": 1.3
+  },
+  "poe/anthropic/claude-opus-4.1": {
+    "input": 13,
+    "output": 64,
+    "cacheWrite": 16,
+    "cacheRead": 1.3
+  },
+  "poe/anthropic/claude-opus-4.5": {
+    "input": 4.3,
+    "output": 21,
+    "cacheWrite": 5.3,
+    "cacheRead": 0.43
+  },
+  "poe/anthropic/claude-opus-4.6": {
+    "input": 4.3,
+    "output": 21,
+    "cacheWrite": 5.3,
+    "cacheRead": 0.43
+  },
+  "poe/anthropic/claude-sonnet-3.5": {
+    "input": 2.6,
+    "output": 13,
+    "cacheWrite": 3.2,
+    "cacheRead": 0.26
+  },
+  "poe/anthropic/claude-sonnet-3.5-june": {
+    "input": 2.6,
+    "output": 13,
+    "cacheWrite": 3.2,
+    "cacheRead": 0.26
+  },
+  "poe/anthropic/claude-sonnet-3.7": {
+    "input": 2.6,
+    "output": 13,
+    "cacheWrite": 3.2,
+    "cacheRead": 0.26
+  },
+  "poe/anthropic/claude-sonnet-4": {
+    "input": 2.6,
+    "output": 13,
+    "cacheWrite": 3.2,
+    "cacheRead": 0.26
+  },
+  "poe/anthropic/claude-sonnet-4.5": {
+    "input": 2.6,
+    "output": 13,
+    "cacheWrite": 3.2,
+    "cacheRead": 0.26
+  },
+  "poe/anthropic/claude-sonnet-4.6": {
+    "input": 2.6,
+    "output": 13,
+    "cacheWrite": 3.2,
+    "cacheRead": 0.26
+  },
+  "poe/fireworks-ai/kimi-k2.5-fw": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/google/gemini-2.0-flash": {
+    "input": 0.1,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/google/gemini-2.0-flash-lite": {
+    "input": 0.052,
+    "output": 0.21,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/google/gemini-2.5-flash": {
+    "input": 0.21,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.021
+  },
+  "poe/google/gemini-2.5-flash-lite": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/google/gemini-2.5-pro": {
+    "input": 0.87,
+    "output": 7,
+    "cacheWrite": 0,
+    "cacheRead": 0.087
+  },
+  "poe/google/gemini-3-flash": {
+    "input": 0.4,
+    "output": 2.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "poe/google/gemini-3-pro": {
+    "input": 1.6,
+    "output": 9.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.16
+  },
+  "poe/google/gemini-3.1-flash-lite": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/google/gemini-3.1-pro": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "poe/google/gemini-deep-research": {
+    "input": 1.6,
+    "output": 9.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/google/nano-banana": {
+    "input": 0.21,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.021
+  },
+  "poe/google/nano-banana-pro": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "poe/novita/deepseek-v3.2": {
+    "input": 0.27,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "poe/openai/chatgpt-4o-latest": {
+    "input": 4.5,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-3.5-turbo": {
+    "input": 0.45,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-3.5-turbo-instruct": {
+    "input": 1.4,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-3.5-turbo-raw": {
+    "input": 0.45,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-4-classic": {
+    "input": 27,
+    "output": 54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-4-classic-0314": {
+    "input": 27,
+    "output": 54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-4-turbo": {
+    "input": 9,
+    "output": 27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-4.1": {
+    "input": 1.8,
+    "output": 7.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.45
+  },
+  "poe/openai/gpt-4.1-mini": {
+    "input": 0.36,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.09
+  },
+  "poe/openai/gpt-4.1-nano": {
+    "input": 0.09,
+    "output": 0.36,
+    "cacheWrite": 0,
+    "cacheRead": 0.022
+  },
+  "poe/openai/gpt-4o-aug": {
+    "input": 2.2,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 1.1
+  },
+  "poe/openai/gpt-4o-mini": {
+    "input": 0.14,
+    "output": 0.54,
+    "cacheWrite": 0,
+    "cacheRead": 0.068
+  },
+  "poe/openai/gpt-4o-mini-search": {
+    "input": 0.14,
+    "output": 0.54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-4o-search": {
+    "input": 2.2,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-5": {
+    "input": 1.1,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "poe/openai/gpt-5-chat": {
+    "input": 1.1,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "poe/openai/gpt-5-codex": {
+    "input": 1.1,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-5-mini": {
+    "input": 0.22,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.022
+  },
+  "poe/openai/gpt-5-nano": {
+    "input": 0.045,
+    "output": 0.36,
+    "cacheWrite": 0,
+    "cacheRead": 0.0045
+  },
+  "poe/openai/gpt-5-pro": {
+    "input": 14,
+    "output": 110,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-5.1": {
+    "input": 1.1,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "poe/openai/gpt-5.1-codex": {
+    "input": 1.1,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "poe/openai/gpt-5.1-codex-max": {
+    "input": 1.1,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "poe/openai/gpt-5.1-codex-mini": {
+    "input": 0.22,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.022
+  },
+  "poe/openai/gpt-5.1-instant": {
+    "input": 1.1,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "poe/openai/gpt-5.2": {
+    "input": 1.6,
+    "output": 13,
+    "cacheWrite": 0,
+    "cacheRead": 0.16
+  },
+  "poe/openai/gpt-5.2-codex": {
+    "input": 1.6,
+    "output": 13,
+    "cacheWrite": 0,
+    "cacheRead": 0.16
+  },
+  "poe/openai/gpt-5.2-instant": {
+    "input": 1.6,
+    "output": 13,
+    "cacheWrite": 0,
+    "cacheRead": 0.16
+  },
+  "poe/openai/gpt-5.2-pro": {
+    "input": 19,
+    "output": 150,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-5.3-codex": {
+    "input": 1.6,
+    "output": 13,
+    "cacheWrite": 0,
+    "cacheRead": 0.16
+  },
+  "poe/openai/gpt-5.3-codex-spark": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/gpt-5.3-instant": {
+    "input": 1.6,
+    "output": 13,
+    "cacheWrite": 0,
+    "cacheRead": 0.16
+  },
+  "poe/openai/gpt-5.4": {
+    "input": 2.2,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.22
+  },
+  "poe/openai/gpt-5.4-mini": {
+    "input": 0.68,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.068
+  },
+  "poe/openai/gpt-5.4-nano": {
+    "input": 0.18,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0.018
+  },
+  "poe/openai/gpt-5.4-pro": {
+    "input": 27,
+    "output": 160,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/o1": {
+    "input": 14,
+    "output": 54,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/o1-pro": {
+    "input": 140,
+    "output": 540,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/o3": {
+    "input": 1.8,
+    "output": 7.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.45
+  },
+  "poe/openai/o3-deep-research": {
+    "input": 9,
+    "output": 36,
+    "cacheWrite": 0,
+    "cacheRead": 2.2
+  },
+  "poe/openai/o3-mini": {
+    "input": 0.99,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/o3-mini-high": {
+    "input": 0.99,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/o3-pro": {
+    "input": 18,
+    "output": 72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "poe/openai/o4-mini": {
+    "input": 0.99,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "poe/openai/o4-mini-deep-research": {
+    "input": 1.8,
+    "output": 7.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.45
+  },
+  "poe/xai/grok-3": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "poe/xai/grok-3-mini": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "poe/xai/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "poe/xai/grok-4-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "poe/xai/grok-4-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "poe/xai/grok-4.20-multi-agent": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "poe/xai/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "privatemode-ai/gemma-3-27b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "privatemode-ai/gpt-oss-120b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "privatemode-ai/qwen3-coder-30b-a3b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "privatemode-ai/qwen3-embedding-4b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "privatemode-ai/whisper-large-v3": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qihang-ai/claude-haiku-4-5-20251001": {
+    "input": 0.14,
+    "output": 0.71,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qihang-ai/claude-opus-4-5-20251101": {
+    "input": 0.71,
+    "output": 3.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qihang-ai/claude-sonnet-4-5-20250929": {
+    "input": 0.43,
+    "output": 2.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qihang-ai/gemini-2.5-flash": {
+    "input": 0.09,
+    "output": 0.71,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qihang-ai/gemini-3-flash-preview": {
+    "input": 0.07,
+    "output": 0.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qihang-ai/gemini-3-pro-preview": {
+    "input": 0.57,
+    "output": 3.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qihang-ai/gpt-5-mini": {
+    "input": 0.04,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qihang-ai/gpt-5.2": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qihang-ai/gpt-5.2-codex": {
+    "input": 0.14,
+    "output": 1.14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-2.5-7b-instruct": {
+    "input": 0.04,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-2.5-7b-vision-instruct": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-2.5-coder-32b": {
+    "input": 0.79,
+    "output": 0.79,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-2.5-coder-32b-instruct": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.015
+  },
+  "qwen-2.5-vl-7b-instruct": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-3-14b": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-3-235b": {
+    "input": 0.13,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-3-235b-a22b-instruct-2507": {
+    "input": 0.6,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-3-30b": {
+    "input": 0.08,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-3-32b": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-coder-plus": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-deep-research": {
+    "input": 7.742,
+    "output": 23.367,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-doc-turbo": {
+    "input": 0.087,
+    "output": 0.144,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-image": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-image-edit-max": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-image-edit-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-image-max": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-image-max-2025-12-30": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-image-plus": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-math-plus": {
+    "input": 0.574,
+    "output": 1.721,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-math-turbo": {
+    "input": 0.287,
+    "output": 0.861,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-plus-2025-07-28": {
+    "input": 0.26,
+    "output": 0.78,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-plus-2025-07-28:thinking": {
+    "input": 0.26,
+    "output": 0.78,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-plus-character": {
+    "input": 0.115,
+    "output": 0.287,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-plus-character-ja": {
+    "input": 0.5,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen-plus-latest": {
+    "input": 0.4,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "qwen-qwq-32b": {
+    "input": 0.29,
+    "output": 0.39,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen.qwen3-235b-a22b-2507-v1:0": {
+    "input": 0.22,
+    "output": 0.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen.qwen3-32b-v1:0": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen.qwen3-coder-30b-a3b-v1:0": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen.qwen3-coder-480b-a35b-v1:0": {
+    "input": 0.22,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen.qwen3-next-80b-a3b": {
+    "input": 0.14,
+    "output": 1.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen.qwen3-vl-235b-a22b": {
     "input": 0.3,
     "output": 1.5,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "qwen/qwen3-coder:exacto": {
+  "qwen2-5-coder-32b-instruct": {
+    "input": 0.287,
+    "output": 0.861,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2-5-coder-7b-instruct": {
+    "input": 0.144,
+    "output": 0.287,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2-5-math-72b-instruct": {
+    "input": 0.574,
+    "output": 1.721,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2-5-math-7b-instruct": {
+    "input": 0.144,
+    "output": 0.287,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2-5-vl-32b-instruct": {
+    "input": 1.4,
+    "output": 4.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2.5-14b-instruct": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2.5-32b-eva-v0.2": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2.5-32b-instruct": {
+    "input": 0.18,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2.5-32b-instruct-abliterated": {
+    "input": 0.7,
+    "output": 0.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2.5-72b-instruct-128k": {
+    "input": 0.59,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2.5-coder-7b-instruct": {
+    "input": 0.03,
+    "output": 0.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2.5-vl-72b-instruct-tee": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "input": 0.05,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen25-coder-7b": {
+    "input": 0.01,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen25-vl-72b-instruct": {
+    "input": 0.69989,
+    "output": 0.69989,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-14b-instruct": {
+    "input": 0.05,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-235b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-235b-a22b-07-25": {
+    "input": 0.15,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-235b-a22b-2507": {
+    "input": 0.071,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-235b-a22b-fp8": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-235b-a22b-instruct": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-235b-a22b-instruct-2507-maas": {
+    "input": 0.22,
+    "output": 0.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-235b-a22b-instruct-2507-tee": {
+    "input": 0.08,
+    "output": 0.55,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "qwen3-235b-a22b-instruct-2507-tput": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-235b-a22b-thinking": {
+    "input": 0.3,
+    "output": 2.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-30b-a3b-2507": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-30b-a3b-instruct-2507-fp8": {
+    "input": 0.35,
+    "output": 1.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-32b-fast": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0.25,
+    "cacheRead": 0.02
+  },
+  "qwen3-32b-fp8": {
+    "input": 0.1,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-4b-fp8": {
+    "input": 0.03,
+    "output": 0.03,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-4b:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-5-35b-a3b": {
+    "input": 0.3125,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.15625
+  },
+  "qwen3-5-9b": {
+    "input": 0.05,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-8b-fp8": {
+    "input": 0.035,
+    "output": 0.138,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-coder-30b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-coder-30b-a3b": {
+    "input": 0.07,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-coder-480b-a35b-instruct-fp8-tee": {
+    "input": 0.22,
+    "output": 0.95,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "qwen3-coder-480b-a35b-instruct-int4-mixed-ar": {
+    "input": 0.22,
+    "output": 0.95,
+    "cacheWrite": 0.44,
+    "cacheRead": 0.11
+  },
+  "qwen3-coder-next-fp8": {
+    "input": 0.5,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-coder:exacto": {
     "input": 0.38,
     "output": 1.53,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "qwen/qwen3-coder:free": {
+  "qwen3-coder:free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "qwen/qwen3-max": {
+  "qwen3-livetranslate-flash-realtime": {
+    "input": 10,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-max-2025-09-23": {
+    "input": 0.86,
+    "output": 3.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-max-preview": {
     "input": 1.2,
     "output": 6,
     "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "qwen3-next-80b": {
+    "input": 0.35,
+    "output": 1.9,
+    "cacheWrite": 0,
     "cacheRead": 0
   },
-  "qwen/qwen3-next-80b-a3b-instruct": {
+  "qwen3-next-80b-a3b-instruct:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-omni-30b-a3b-captioner": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-vl-235b-a22b-instruct-fp8": {
+    "input": 1.64,
+    "output": 1.91,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-vl-235b-a22b-instruct-original": {
+    "input": 0.5,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-vl-32b-thinking": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-vl-embedding-8b": {
+    "input": 0.09,
+    "output": 0.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-vl-flash": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "qwen3-vl-instruct": {
+    "input": 0.7,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3-vl-thinking": {
+    "input": 0.7,
+    "output": 8.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3.5-397b-a17b-tee": {
+    "input": 0.39,
+    "output": 2.34,
+    "cacheWrite": 0,
+    "cacheRead": 0.195
+  },
+  "qwen3.5-4b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3.5-flash-02-23": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3.6-plus-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3.6-plus-preview:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3.6-plus:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen35-397b-a17b": {
+    "input": 0.6,
+    "output": 3.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwen3guard-gen-0.6b": {
+    "input": 0.01,
+    "output": 0.01,
+    "cacheWrite": 0,
+    "cacheRead": 0.005
+  },
+  "qwenlong-l1-32b": {
+    "input": 0.14,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwerky-72b": {
+    "input": 0.5,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "qwq-32b-arliai-rpr-v1": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "r1v4-lite": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "relace-apply-3": {
+    "input": 0.85,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "relace-search": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "requesty/anthropic/claude-3-7-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "requesty/anthropic/claude-haiku-4-5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "requesty/anthropic/claude-opus-4": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "requesty/anthropic/claude-opus-4-1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "requesty/anthropic/claude-opus-4-5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "requesty/anthropic/claude-opus-4-6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "requesty/anthropic/claude-sonnet-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "requesty/anthropic/claude-sonnet-4-5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "requesty/anthropic/claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "requesty/google/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0.55,
+    "cacheRead": 0.075
+  },
+  "requesty/google/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 2.375,
+    "cacheRead": 0.31
+  },
+  "requesty/google/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 1,
+    "cacheRead": 0.05
+  },
+  "requesty/google/gemini-3-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 4.5,
+    "cacheRead": 0.2
+  },
+  "requesty/openai/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "requesty/openai/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "requesty/openai/gpt-4o-mini": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "requesty/openai/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "requesty/openai/gpt-5-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "requesty/openai/gpt-5-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "requesty/openai/gpt-5-image": {
+    "input": 5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "requesty/openai/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "requesty/openai/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "requesty/openai/gpt-5-pro": {
+    "input": 15,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "requesty/openai/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "requesty/openai/gpt-5.1-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "requesty/openai/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "requesty/openai/gpt-5.1-codex-max": {
+    "input": 1.1,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "requesty/openai/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "requesty/openai/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "requesty/openai/gpt-5.2-chat": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "requesty/openai/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "requesty/openai/gpt-5.2-pro": {
+    "input": 21,
+    "output": 168,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "requesty/openai/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "requesty/openai/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "requesty/openai/gpt-5.4-pro": {
+    "input": 30,
+    "output": 180,
+    "cacheWrite": 0,
+    "cacheRead": 30
+  },
+  "requesty/openai/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.28
+  },
+  "requesty/xai/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3,
+    "cacheRead": 0.75
+  },
+  "requesty/xai/grok-4-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0.2,
+    "cacheRead": 0.05
+  },
+  "ring-flash-2.0": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "riverflow-v2-fast-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "riverflow-v2-max-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "riverflow-v2-standard-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "rnj-1-instruct": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "rocinante-12b": {
+    "input": 0.17,
+    "output": 0.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "rocinante-12b-v1.1": {
+    "input": 0.408,
+    "output": 0.595,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "route-llm": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "router": {
+    "input": 0.85,
+    "output": 3.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "sap-ai-core/anthropic--claude-3-haiku": {
+    "input": 0.25,
+    "output": 1.25,
+    "cacheWrite": 0.3,
+    "cacheRead": 0.03
+  },
+  "sap-ai-core/anthropic--claude-3-opus": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "sap-ai-core/anthropic--claude-3-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "sap-ai-core/anthropic--claude-3.5-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "sap-ai-core/anthropic--claude-3.7-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "sap-ai-core/anthropic--claude-4-opus": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "sap-ai-core/anthropic--claude-4-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "sap-ai-core/anthropic--claude-4.5-haiku": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "sap-ai-core/anthropic--claude-4.5-opus": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "sap-ai-core/anthropic--claude-4.5-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "sap-ai-core/anthropic--claude-4.6-opus": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "sap-ai-core/anthropic--claude-4.6-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "sap-ai-core/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "sap-ai-core/gemini-2.5-flash-lite": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "sap-ai-core/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "sap-ai-core/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "sap-ai-core/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "sap-ai-core/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "sap-ai-core/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "sap-ai-core/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.005
+  },
+  "sap-ai-core/sonar": {
+    "input": 1,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "sap-ai-core/sonar-deep-research": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "sap-ai-core/sonar-pro": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "sarvan-medium": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/bge-multilingual-gemma2": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/deepseek-r1-distill-llama-70b": {
+    "input": 0.9,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/devstral-2-123b-instruct-2512": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/gemma-3-27b-it": {
+    "input": 0.25,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/gpt-oss-120b": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/llama-3.1-8b-instruct": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/llama-3.3-70b-instruct": {
+    "input": 0.9,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/mistral-nemo-instruct-2407": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/mistral-small-3.2-24b-instruct-2506": {
+    "input": 0.15,
+    "output": 0.35,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/pixtral-12b-2409": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.75,
+    "output": 2.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/qwen3-embedding-8b": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/qwen3.5-397b-a17b": {
+    "input": 0.6,
+    "output": 3.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/voxtral-small-24b-2507": {
+    "input": 0.15,
+    "output": 0.35,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "scaleway/whisper-large-v3": {
+    "input": 0.003,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "seed-1-6-250615": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "seed-1-6-250915": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "seed-1-6-flash-250715": {
+    "input": 0.07,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "seed-1-8-251228": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "seed-1.6-flash": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "seed-1.8": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "seed-2.0-lite": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "seed-2.0-mini": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "seed-oss-36b-instruct": {
+    "input": 0.21,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "seedream-4-0": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "seedream-4-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "seedream-4.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "shisa-v2-llama3.3-70b": {
+    "input": 0.5,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "shisa-v2.1-llama3.3-70b": {
+    "input": 0.5,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/ascend-tribe/pangu-pro-moe": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/baidu/ernie-4.5-300b-a47b": {
+    "input": 0.28,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/bytedance-seed/seed-oss-36b-instruct": {
+    "input": 0.21,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/deepseek-ai/deepseek-ocr": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/deepseek-ai/deepseek-r1": {
+    "input": 0.5,
+    "output": 2.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/deepseek-ai/deepseek-r1-distill-qwen-14b": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+    "input": 0.18,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/deepseek-ai/deepseek-v3": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/deepseek-ai/deepseek-v3.1-terminus": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/deepseek-ai/deepseek-v3.2": {
+    "input": 0.27,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/deepseek-ai/deepseek-vl2": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/inclusionai/ling-flash-2.0": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/inclusionai/ling-mini-2.0": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/inclusionai/ring-flash-2.0": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/kwaipilot/kat-dev": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/moonshotai/kimi-k2-instruct-0905": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/moonshotai/kimi-k2-thinking": {
+    "input": 0.55,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/paddlepaddle/paddleocr-vl": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/paddlepaddle/paddleocr-vl-1.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/pro/deepseek-ai/deepseek-r1": {
+    "input": 0.5,
+    "output": 2.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/pro/deepseek-ai/deepseek-v3": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/pro/deepseek-ai/deepseek-v3.1-terminus": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/pro/deepseek-ai/deepseek-v3.2": {
+    "input": 0.27,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/pro/minimaxai/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/pro/minimaxai/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/pro/moonshotai/kimi-k2-instruct-0905": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/pro/moonshotai/kimi-k2-thinking": {
+    "input": 0.55,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/pro/moonshotai/kimi-k2.5": {
+    "input": 0.55,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/pro/zai-org/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/pro/zai-org/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen2.5-14b-instruct": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen2.5-32b-instruct": {
+    "input": 0.18,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen2.5-72b-instruct": {
+    "input": 0.59,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen2.5-72b-instruct-128k": {
+    "input": 0.59,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen2.5-7b-instruct": {
+    "input": 0.05,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen2.5-coder-32b-instruct": {
+    "input": 0.18,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen2.5-vl-32b-instruct": {
+    "input": 0.27,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen2.5-vl-72b-instruct": {
+    "input": 0.59,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-14b": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.09,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.13,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-30b-a3b-instruct-2507": {
+    "input": 0.09,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-30b-a3b-thinking-2507": {
+    "input": 0.09,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-32b": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-8b": {
+    "input": 0.06,
+    "output": 0.06,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-next-80b-a3b-instruct": {
     "input": 0.14,
     "output": 1.4,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "qwen/qwen3-next-80b-a3b-instruct:free": {
+  "siliconflow-cn/qwen/qwen3-next-80b-a3b-thinking": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-omni-30b-a3b-captioner": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-omni-30b-a3b-instruct": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-omni-30b-a3b-thinking": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-vl-235b-a22b-instruct": {
+    "input": 0.3,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-vl-235b-a22b-thinking": {
+    "input": 0.45,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-vl-30b-a3b-instruct": {
+    "input": 0.29,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-vl-30b-a3b-thinking": {
+    "input": 0.29,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-vl-32b-instruct": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-vl-32b-thinking": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-vl-8b-instruct": {
+    "input": 0.18,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3-vl-8b-thinking": {
+    "input": 0.18,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3.5-122b-a10b": {
+    "input": 0.29,
+    "output": 2.32,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3.5-27b": {
+    "input": 0.26,
+    "output": 2.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3.5-35b-a3b": {
+    "input": 0.23,
+    "output": 1.86,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3.5-397b-a17b": {
+    "input": 0.29,
+    "output": 1.74,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwen3.5-4b": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "qwen/qwen3-next-80b-a3b-thinking": {
+  "siliconflow-cn/qwen/qwen3.5-9b": {
+    "input": 0.22,
+    "output": 1.74,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/qwen/qwq-32b": {
+    "input": 0.15,
+    "output": 0.58,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/stepfun-ai/step-3.5-flash": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/tencent/hunyuan-a13b-instruct": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/tencent/hunyuan-mt-7b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/thudm/glm-4-32b-0414": {
+    "input": 0.27,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/thudm/glm-4-9b-0414": {
+    "input": 0.086,
+    "output": 0.086,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/thudm/glm-z1-32b-0414": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/thudm/glm-z1-9b-0414": {
+    "input": 0.086,
+    "output": 0.086,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/zai-org/glm-4.5-air": {
+    "input": 0.14,
+    "output": 0.86,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/zai-org/glm-4.5v": {
+    "input": 0.14,
+    "output": 0.86,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/zai-org/glm-4.6": {
+    "input": 0.5,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow-cn/zai-org/glm-4.6v": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/baidu/ernie-4.5-300b-a47b": {
+    "input": 0.28,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/bytedance-seed/seed-oss-36b-instruct": {
+    "input": 0.21,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/deepseek-ai/deepseek-r1": {
+    "input": 0.5,
+    "output": 2.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/deepseek-ai/deepseek-r1-distill-qwen-14b": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+    "input": 0.18,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/deepseek-ai/deepseek-v3": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/deepseek-ai/deepseek-v3.1": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/deepseek-ai/deepseek-v3.1-terminus": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/deepseek-ai/deepseek-v3.2": {
+    "input": 0.27,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/deepseek-ai/deepseek-v3.2-exp": {
+    "input": 0.27,
+    "output": 0.41,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/deepseek-ai/deepseek-vl2": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/inclusionai/ling-flash-2.0": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/inclusionai/ling-mini-2.0": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/inclusionai/ring-flash-2.0": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/meta-llama/meta-llama-3.1-8b-instruct": {
+    "input": 0.06,
+    "output": 0.06,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/minimaxai/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/minimaxai/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/moonshotai/kimi-k2-instruct": {
+    "input": 0.58,
+    "output": 2.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/moonshotai/kimi-k2-instruct-0905": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/moonshotai/kimi-k2-thinking": {
+    "input": 0.55,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/moonshotai/kimi-k2.5": {
+    "input": 0.55,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/nex-agi/deepseek-v3.1-nex-n1": {
+    "input": 0.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/openai/gpt-oss-120b": {
+    "input": 0.05,
+    "output": 0.45,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/openai/gpt-oss-20b": {
+    "input": 0.04,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen2.5-14b-instruct": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen2.5-32b-instruct": {
+    "input": 0.18,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen2.5-72b-instruct": {
+    "input": 0.59,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen2.5-72b-instruct-128k": {
+    "input": 0.59,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen2.5-7b-instruct": {
+    "input": 0.05,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen2.5-coder-32b-instruct": {
+    "input": 0.18,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen2.5-vl-32b-instruct": {
+    "input": 0.27,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen2.5-vl-72b-instruct": {
+    "input": 0.59,
+    "output": 0.59,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen2.5-vl-7b-instruct": {
+    "input": 0.05,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-14b": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-235b-a22b": {
+    "input": 0.35,
+    "output": 1.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.09,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.13,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-30b-a3b-instruct-2507": {
+    "input": 0.09,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-30b-a3b-thinking-2507": {
+    "input": 0.09,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-32b": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-8b": {
+    "input": 0.06,
+    "output": 0.06,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-coder-30b-a3b-instruct": {
+    "input": 0.07,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-next-80b-a3b-instruct": {
     "input": 0.14,
     "output": 1.4,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "qwen/qwq-32b:free": {
+  "siliconflow/qwen/qwen3-next-80b-a3b-thinking": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-omni-30b-a3b-captioner": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-omni-30b-a3b-instruct": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-omni-30b-a3b-thinking": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-vl-235b-a22b-instruct": {
+    "input": 0.3,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-vl-235b-a22b-thinking": {
+    "input": 0.45,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-vl-30b-a3b-instruct": {
+    "input": 0.29,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-vl-30b-a3b-thinking": {
+    "input": 0.29,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-vl-32b-instruct": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-vl-32b-thinking": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-vl-8b-instruct": {
+    "input": 0.18,
+    "output": 0.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwen3-vl-8b-thinking": {
+    "input": 0.18,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/qwen/qwq-32b": {
+    "input": 0.15,
+    "output": 0.58,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/stepfun-ai/step-3.5-flash": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/tencent/hunyuan-a13b-instruct": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/tencent/hunyuan-mt-7b": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "qwen3-coder": {
+  "siliconflow/thudm/glm-4-32b-0414": {
+    "input": 0.27,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/thudm/glm-4-9b-0414": {
+    "input": 0.086,
+    "output": 0.086,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/thudm/glm-z1-32b-0414": {
+    "input": 0.14,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/thudm/glm-z1-9b-0414": {
+    "input": 0.086,
+    "output": 0.086,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/zai-org/glm-4.5": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/zai-org/glm-4.5-air": {
+    "input": 0.14,
+    "output": 0.86,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/zai-org/glm-4.5v": {
+    "input": 0.14,
+    "output": 0.86,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/zai-org/glm-4.6": {
+    "input": 0.5,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/zai-org/glm-4.6v": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/zai-org/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "siliconflow/zai-org/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "small": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "smart-turn-v2": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "rekaai/reka-flash-3": {
+  "solar-mini": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "solar-pro-3": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "solar-pro2": {
+    "input": 0.25,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "solar-pro3": {
+    "input": 0.25,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "sonar-pro-search": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "sonar-reasoning": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "sorcererlm-8x22b": {
+    "input": 4.505,
+    "output": 4.505,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "spotlight": {
+    "input": 0.18,
+    "output": 0.18,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "stackit/cortecs/llama-3.3-70b-instruct-fp8-dynamic": {
+    "input": 0.49,
+    "output": 0.71,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "stackit/google/gemma-3-27b-it": {
+    "input": 0.49,
+    "output": 0.71,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "stackit/intfloat/e5-mistral-7b-instruct": {
+    "input": 0.02,
+    "output": 0.02,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "stackit/neuralmagic/meta-llama-3.1-8b-instruct-fp8": {
+    "input": 0.16,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "stackit/neuralmagic/mistral-nemo-instruct-2407-fp8": {
+    "input": 0.49,
+    "output": 0.71,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "stackit/openai/gpt-oss-120b": {
+    "input": 0.49,
+    "output": 0.71,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "stackit/qwen/qwen3-vl-235b-a22b-instruct-fp8": {
+    "input": 1.64,
+    "output": 1.91,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "stackit/qwen/qwen3-vl-embedding-8b": {
+    "input": 0.09,
+    "output": 0.09,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "starcannon-unleashed-12b-v1.0": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "step-1-32k": {
+    "input": 2.05,
+    "output": 9.59,
+    "cacheWrite": 0,
+    "cacheRead": 0.41
+  },
+  "step-2-16k": {
+    "input": 5.21,
+    "output": 16.44,
+    "cacheWrite": 0,
+    "cacheRead": 1.04
+  },
+  "step-2-16k-exp": {
+    "input": 7.004,
+    "output": 19.992,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "step-2-mini": {
+    "input": 0.2006,
+    "output": 0.408,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "step-3.5-flash-free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "sarvamai/sarvam-m:free": {
+  "step-3.5-flash:free": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "sourceful/riverflow-v2-fast-preview": {
+  "step-3.5-flash:thinking": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "step-r1-v-mini": {
+    "input": 2.5,
+    "output": 11,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "stepfun/step-1-32k": {
+    "input": 2.05,
+    "output": 9.59,
+    "cacheWrite": 0,
+    "cacheRead": 0.41
+  },
+  "stepfun/step-2-16k": {
+    "input": 5.21,
+    "output": 16.44,
+    "cacheWrite": 0,
+    "cacheRead": 1.04
+  },
+  "stepfun/step-3.5-flash": {
+    "input": 0.096,
+    "output": 0.288,
+    "cacheWrite": 0,
+    "cacheRead": 0.019
+  },
+  "study_gpt-chatgpt-4o-latest": {
+    "input": 4.998,
+    "output": 14.994,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "submodel/deepseek-ai/deepseek-r1-0528": {
+    "input": 0.5,
+    "output": 2.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "submodel/deepseek-ai/deepseek-v3-0324": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "submodel/deepseek-ai/deepseek-v3.1": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "submodel/openai/gpt-oss-120b": {
+    "input": 0.1,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "submodel/qwen/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.2,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "submodel/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "submodel/qwen/qwen3-coder-480b-a35b-instruct-fp8": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "submodel/zai-org/glm-4.5-air": {
+    "input": 0.1,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "submodel/zai-org/glm-4.5-fp8": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:deepseek-ai/deepseek-r1": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:deepseek-ai/deepseek-r1-0528": {
+    "input": 3,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:deepseek-ai/deepseek-v3": {
+    "input": 1.25,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:deepseek-ai/deepseek-v3-0324": {
+    "input": 1.2,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:deepseek-ai/deepseek-v3.1": {
+    "input": 0.56,
+    "output": 1.68,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:deepseek-ai/deepseek-v3.1-terminus": {
+    "input": 1.2,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:deepseek-ai/deepseek-v3.2": {
+    "input": 0.27,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.27
+  },
+  "synthetic/hf:meta-llama/llama-3.1-405b-instruct": {
+    "input": 3,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:meta-llama/llama-3.1-70b-instruct": {
+    "input": 0.9,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:meta-llama/llama-3.1-8b-instruct": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:meta-llama/llama-3.3-70b-instruct": {
+    "input": 0.9,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+    "input": 0.22,
+    "output": 0.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:meta-llama/llama-4-scout-17b-16e-instruct": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:minimaxai/minimax-m2": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:minimaxai/minimax-m2.1": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:minimaxai/minimax-m2.5": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.6
+  },
+  "synthetic/hf:moonshotai/kimi-k2-instruct-0905": {
+    "input": 1.2,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:moonshotai/kimi-k2-thinking": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:moonshotai/kimi-k2.5": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:nvidia/kimi-k2.5-nvfp4": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:openai/gpt-oss-120b": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:qwen/qwen2.5-coder-32b-instruct": {
+    "input": 0.8,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:qwen/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.65,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": 2,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:qwen/qwen3.5-397b-a17b": {
+    "input": 0.6,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.6
+  },
+  "synthetic/hf:zai-org/glm-4.6": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:zai-org/glm-4.7": {
+    "input": 0.55,
+    "output": 2.19,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "synthetic/hf:zai-org/glm-4.7-flash": {
+    "input": 0.06,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "tc-code-latest": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "sourceful/riverflow-v2-max-preview": {
+  "tencent-coding-plan/glm-5": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "sourceful/riverflow-v2-standard-preview": {
+  "tencent-coding-plan/hunyuan-2.0-instruct": {
     "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "tencent-coding-plan/hunyuan-2.0-thinking": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "tencent-coding-plan/hunyuan-t1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "tencent-coding-plan/hunyuan-turbos": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "tencent-coding-plan/kimi-k2.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "tencent-coding-plan/minimax-m2.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "tencent-coding-plan/tc-code-latest": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "text-embedding-005": {
+    "input": 0.03,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
@@ -1835,71 +27719,2345 @@
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "thudm/glm-z1-32b:free": {
-    "input": 0,
+  "text-multilingual-embedding-002": {
+    "input": 0.03,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "tngtech/deepseek-r1t2-chimera:free": {
-    "input": 0,
+  "the-omega-abomination-l-70b-v1.0": {
+    "input": 0.7,
+    "output": 0.95,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "titan-embed-text-v2": {
+    "input": 0.02,
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "tngtech/tng-r1t-chimera:free": {
-    "input": 0,
-    "output": 0,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "x-ai/grok-3": {
-    "input": 3,
-    "output": 15,
-    "cacheWrite": 15,
-    "cacheRead": 0.75
-  },
-  "x-ai/grok-3-beta": {
-    "input": 3,
-    "output": 15,
-    "cacheWrite": 15,
-    "cacheRead": 0.75
-  },
-  "x-ai/grok-3-mini": {
+  "tng-r1t-chimera": {
     "input": 0.3,
-    "output": 0.5,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "tng-r1t-chimera-tee": {
+    "input": 0.25,
+    "output": 0.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "tng-r1t-chimera-turbo": {
+    "input": 0.22,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/deepseek-ai/deepseek-r1": {
+    "input": 3,
+    "output": 7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/deepseek-ai/deepseek-v3": {
+    "input": 1.25,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/deepseek-ai/deepseek-v3-1": {
+    "input": 0.6,
+    "output": 1.7,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/essentialai/rnj-1-instruct": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/meta-llama/llama-3.3-70b-instruct-turbo": {
+    "input": 0.88,
+    "output": 0.88,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/minimaxai/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "togetherai/moonshotai/kimi-k2-instruct": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/moonshotai/kimi-k2.5": {
+    "input": 0.5,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/openai/gpt-oss-120b": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/qwen/qwen3-235b-a22b-instruct-2507-tput": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/qwen/qwen3-coder-480b-a35b-instruct-fp8": {
+    "input": 2,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/qwen/qwen3-coder-next-fp8": {
+    "input": 0.5,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/qwen/qwen3-next-80b-a3b-instruct": {
+    "input": 0.15,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/qwen/qwen3.5-397b-a17b": {
+    "input": 0.6,
+    "output": 3.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/zai-org/glm-4.6": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/zai-org/glm-4.7": {
+    "input": 0.45,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "togetherai/zai-org/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "tongyi-intent-detect-v3": {
+    "input": 0.058,
+    "output": 0.144,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "trinity-large": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "trinity-large-preview": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "trinity-large-preview-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "trinity-large-preview:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "trinity-large-thinking": {
+    "input": 0.25,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "trinity-mini:free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "ui-tars-1.5-7b": {
+    "input": 0.1,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "universal-summarizer": {
+    "input": 30,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "unslopnemo-12b": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "unslopnemo-12b-v4.1": {
+    "input": 0.493,
+    "output": 0.493,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "upstage/solar-mini": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "upstage/solar-pro2": {
+    "input": 0.25,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "upstage/solar-pro3": {
+    "input": 0.25,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "us.anthropic.claude-opus-4-1-20250805-v1:0": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "us.anthropic.claude-opus-4-20250514-v1:0": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "us.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "us.anthropic.claude-opus-4-6-v1": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "us.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "us.anthropic.claude-sonnet-4-6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "v0-1.0-md": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "v0-1.5-lg": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "v0-1.5-md": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "v0/v0-1.0-md": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "v0/v0-1.5-lg": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "v0/v0-1.5-md": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "veiled-calla-12b": {
+    "input": 0.3,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice-uncensored-role-play": {
+    "input": 0.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice-uncensored:web": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/aion-labs.aion-2-0": {
+    "input": 1,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "venice/claude-opus-4-6": {
+    "input": 6,
+    "output": 30,
+    "cacheWrite": 7.5,
+    "cacheRead": 0.6
+  },
+  "venice/claude-opus-45": {
+    "input": 6,
+    "output": 30,
+    "cacheWrite": 7.5,
+    "cacheRead": 0.6
+  },
+  "venice/claude-sonnet-4-6": {
+    "input": 3.6,
+    "output": 18,
+    "cacheWrite": 4.5,
+    "cacheRead": 0.36
+  },
+  "venice/claude-sonnet-45": {
+    "input": 3.75,
+    "output": 18.75,
+    "cacheWrite": 4.69,
+    "cacheRead": 0.375
+  },
+  "venice/deepseek-v3.2": {
+    "input": 0.33,
+    "output": 0.48,
+    "cacheWrite": 0,
+    "cacheRead": 0.16
+  },
+  "venice/gemini-3-1-pro-preview": {
+    "input": 2.5,
+    "output": 15,
     "cacheWrite": 0.5,
+    "cacheRead": 0.5
+  },
+  "venice/gemini-3-flash-preview": {
+    "input": 0.7,
+    "output": 3.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.07
+  },
+  "venice/google-gemma-3-27b-it": {
+    "input": 0.12,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/grok-4-20-beta": {
+    "input": 2.5,
+    "output": 7.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "venice/grok-4-20-multi-agent-beta": {
+    "input": 2.5,
+    "output": 7.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "venice/grok-41-fast": {
+    "input": 0.25,
+    "output": 0.625,
+    "cacheWrite": 0,
+    "cacheRead": 0.0625
+  },
+  "venice/grok-code-fast-1": {
+    "input": 0.25,
+    "output": 1.87,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "venice/hermes-3-llama-3.1-405b": {
+    "input": 1.1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/kimi-k2-5": {
+    "input": 0.56,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "venice/kimi-k2-thinking": {
+    "input": 0.75,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.375
+  },
+  "venice/llama-3.2-3b": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/llama-3.3-70b": {
+    "input": 0.7,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/minimax-m21": {
+    "input": 0.35,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "venice/minimax-m25": {
+    "input": 0.34,
+    "output": 1.19,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "venice/minimax-m27": {
+    "input": 0.375,
+    "output": 1.5,
+    "cacheWrite": 0,
     "cacheRead": 0.075
   },
-  "x-ai/grok-3-mini-beta": {
-    "input": 0.3,
-    "output": 0.5,
-    "cacheWrite": 0.5,
-    "cacheRead": 0.075
+  "venice/mistral-small-3-2-24b-instruct": {
+    "input": 0.09375,
+    "output": 0.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
   },
-  "x-ai/grok-4": {
+  "venice/nvidia-nemotron-3-nano-30b-a3b": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/olafangensan-glm-4.7-flash-heretic": {
+    "input": 0.14,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/openai-gpt-4o-2024-11-20": {
+    "input": 3.125,
+    "output": 12.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/openai-gpt-4o-mini-2024-07-18": {
+    "input": 0.1875,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.09375
+  },
+  "venice/openai-gpt-52": {
+    "input": 2.19,
+    "output": 17.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.219
+  },
+  "venice/openai-gpt-52-codex": {
+    "input": 2.19,
+    "output": 17.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.219
+  },
+  "venice/openai-gpt-53-codex": {
+    "input": 2.19,
+    "output": 17.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.219
+  },
+  "venice/openai-gpt-54": {
+    "input": 3.13,
+    "output": 18.8,
+    "cacheWrite": 0,
+    "cacheRead": 0.313
+  },
+  "venice/openai-gpt-54-mini": {
+    "input": 0.9375,
+    "output": 5.625,
+    "cacheWrite": 0,
+    "cacheRead": 0.09375
+  },
+  "venice/openai-gpt-54-pro": {
+    "input": 37.5,
+    "output": 225,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/openai-gpt-oss-120b": {
+    "input": 0.07,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.15,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.45,
+    "output": 3.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/qwen3-5-35b-a3b": {
+    "input": 0.3125,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.15625
+  },
+  "venice/qwen3-5-9b": {
+    "input": 0.05,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/qwen3-coder-480b-a35b-instruct": {
+    "input": 0.75,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/qwen3-coder-480b-a35b-instruct-turbo": {
+    "input": 0.35,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "venice/qwen3-next-80b": {
+    "input": 0.35,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/qwen3-vl-235b-a22b": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/venice-uncensored": {
+    "input": 0.2,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/venice-uncensored-role-play": {
+    "input": 0.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/zai-org-glm-4.6": {
+    "input": 0.85,
+    "output": 2.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "venice/zai-org-glm-4.7": {
+    "input": 0.55,
+    "output": 2.65,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "venice/zai-org-glm-4.7-flash": {
+    "input": 0.125,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "venice/zai-org-glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "veo-3.1-fast-generate-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "veo-3.1-generate-preview": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen-3-14b": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen-3-235b": {
+    "input": 0.13,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen-3-30b": {
+    "input": 0.08,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen-3-32b": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-235b-a22b-thinking": {
+    "input": 0.3,
+    "output": 2.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-coder": {
+    "input": 0.38,
+    "output": 1.53,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-coder-30b-a3b": {
+    "input": 0.07,
+    "output": 0.27,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-coder-next": {
+    "input": 0.5,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-coder-plus": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-embedding-0.6b": {
+    "input": 0.01,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-embedding-4b": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-embedding-8b": {
+    "input": 0.05,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-max": {
+    "input": 1.2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-max-preview": {
+    "input": 1.2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "vercel/alibaba/qwen3-max-thinking": {
+    "input": 1.2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "vercel/alibaba/qwen3-next-80b-a3b-instruct": {
+    "input": 0.09,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-next-80b-a3b-thinking": {
+    "input": 0.15,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-vl-instruct": {
+    "input": 0.7,
+    "output": 2.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3-vl-thinking": {
+    "input": 0.7,
+    "output": 8.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/alibaba/qwen3.5-flash": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0.125,
+    "cacheRead": 0.001
+  },
+  "vercel/alibaba/qwen3.5-plus": {
+    "input": 0.4,
+    "output": 2.4,
+    "cacheWrite": 0.5,
+    "cacheRead": 0.04
+  },
+  "vercel/alibaba/qwen3.6-plus": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0.625,
+    "cacheRead": 0.1
+  },
+  "vercel/amazon/nova-2-lite": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/amazon/nova-lite": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0.015
+  },
+  "vercel/amazon/nova-micro": {
+    "input": 0.035,
+    "output": 0.14,
+    "cacheWrite": 0,
+    "cacheRead": 0.00875
+  },
+  "vercel/amazon/nova-pro": {
+    "input": 0.8,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vercel/amazon/titan-embed-text-v2": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/anthropic/claude-3-haiku": {
+    "input": 0.25,
+    "output": 1.25,
+    "cacheWrite": 0.3,
+    "cacheRead": 0.03
+  },
+  "vercel/anthropic/claude-3-opus": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "vercel/anthropic/claude-3.5-haiku": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "vercel/anthropic/claude-3.5-sonnet": {
     "input": 3,
     "output": 15,
-    "cacheWrite": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "vercel/anthropic/claude-3.5-sonnet-20240620": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/anthropic/claude-3.7-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "vercel/anthropic/claude-haiku-4.5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "vercel/anthropic/claude-opus-4": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "vercel/anthropic/claude-opus-4.1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "vercel/anthropic/claude-opus-4.5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 18.75,
+    "cacheRead": 0.5
+  },
+  "vercel/anthropic/claude-opus-4.6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "vercel/anthropic/claude-sonnet-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "vercel/anthropic/claude-sonnet-4.5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "vercel/anthropic/claude-sonnet-4.6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "vercel/arcee-ai/trinity-large-preview": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/arcee-ai/trinity-large-thinking": {
+    "input": 0.25,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/arcee-ai/trinity-mini": {
+    "input": 0.05,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/bytedance/seed-1.6": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "vercel/bytedance/seed-1.8": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "vercel/cohere/command-a": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/cohere/embed-v4.0": {
+    "input": 0.12,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/deepseek/deepseek-r1": {
+    "input": 1.35,
+    "output": 5.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/deepseek/deepseek-v3": {
+    "input": 0.77,
+    "output": 0.77,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/deepseek/deepseek-v3.1": {
+    "input": 0.3,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/deepseek/deepseek-v3.1-terminus": {
+    "input": 0.27,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/deepseek/deepseek-v3.2": {
+    "input": 0.27,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.22
+  },
+  "vercel/deepseek/deepseek-v3.2-exp": {
+    "input": 0.27,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/deepseek/deepseek-v3.2-thinking": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "vercel/google/gemini-2.0-flash": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "vercel/google/gemini-2.0-flash-lite": {
+    "input": 0.075,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/google/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "vercel/google/gemini-2.5-flash-image": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/google/gemini-2.5-flash-image-preview": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/google/gemini-2.5-flash-lite": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "vercel/google/gemini-2.5-flash-lite-preview-09-2025": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "vercel/google/gemini-2.5-flash-preview-09-2025": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 0.383,
+    "cacheRead": 0.03
+  },
+  "vercel/google/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.31
+  },
+  "vercel/google/gemini-3-flash": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "vercel/google/gemini-3-pro-image": {
+    "input": 2,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/google/gemini-3-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vercel/google/gemini-3.1-flash-image-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/google/gemini-3.1-flash-lite-preview": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 1,
+    "cacheRead": 0.025
+  },
+  "vercel/google/gemini-3.1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vercel/google/gemini-embedding-001": {
+    "input": 0.15,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/google/gemma-4-26b-a4b-it": {
+    "input": 0.13,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/google/gemma-4-31b-it": {
+    "input": 0.14,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/google/text-embedding-005": {
+    "input": 0.03,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/google/text-multilingual-embedding-002": {
+    "input": 0.03,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/inception/mercury-2": {
+    "input": 0.25,
+    "output": 0.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "vercel/inception/mercury-coder-small": {
+    "input": 0.25,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/kwaipilot/kat-coder-pro-v2": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "vercel/meituan/longcat-flash-thinking": {
+    "input": 0.15,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/meta/llama-3.1-70b": {
+    "input": 0.4,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/meta/llama-3.1-8b": {
+    "input": 0.03,
+    "output": 0.05,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/meta/llama-3.2-11b": {
+    "input": 0.16,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/meta/llama-3.2-1b": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/meta/llama-3.2-3b": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/meta/llama-3.2-90b": {
+    "input": 0.72,
+    "output": 0.72,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/meta/llama-3.3-70b": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/meta/llama-4-maverick": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/meta/llama-4-scout": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/minimax/minimax-m2": {
+    "input": 0.27,
+    "output": 1.15,
+    "cacheWrite": 0.38,
+    "cacheRead": 0.03
+  },
+  "vercel/minimax/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.38,
+    "cacheRead": 0.03
+  },
+  "vercel/minimax/minimax-m2.1-lightning": {
+    "input": 0.3,
+    "output": 2.4,
+    "cacheWrite": 0.38,
+    "cacheRead": 0.03
+  },
+  "vercel/minimax/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.03
+  },
+  "vercel/minimax/minimax-m2.5-highspeed": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.03
+  },
+  "vercel/minimax/minimax-m2.7": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "vercel/minimax/minimax-m2.7-highspeed": {
+    "input": 0.6,
+    "output": 2.4,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.06
+  },
+  "vercel/mistral/codestral": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/codestral-embed": {
+    "input": 0.15,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/devstral-small": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/magistral-medium": {
+    "input": 2,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/magistral-small": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/ministral-14b": {
+    "input": 0.2,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/ministral-3b": {
+    "input": 0.04,
+    "output": 0.04,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/ministral-8b": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/mistral-embed": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/mistral-large-3": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/mistral-medium": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/mistral-nemo": {
+    "input": 0.04,
+    "output": 0.17,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/mistral-small": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/mixtral-8x22b-instruct": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/pixtral-12b": {
+    "input": 0.15,
+    "output": 0.15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/mistral/pixtral-large": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/moonshotai/kimi-k2": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/moonshotai/kimi-k2-0905": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/moonshotai/kimi-k2-thinking": {
+    "input": 0.47,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.14
+  },
+  "vercel/moonshotai/kimi-k2-thinking-turbo": {
+    "input": 1.15,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "vercel/moonshotai/kimi-k2-turbo": {
+    "input": 2.4,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/moonshotai/kimi-k2.5": {
+    "input": 0.6,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/morph/morph-v3-fast": {
+    "input": 0.8,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/morph/morph-v3-large": {
+    "input": 0.9,
+    "output": 1.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/nvidia/nemotron-3-nano-30b-a3b": {
+    "input": 0.06,
+    "output": 0.24,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/nvidia/nemotron-3-super-120b-a12b": {
+    "input": 0.15,
+    "output": 0.65,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/nvidia/nemotron-nano-12b-v2-vl": {
+    "input": 0.2,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/nvidia/nemotron-nano-9b-v2": {
+    "input": 0.04,
+    "output": 0.16,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/codex-mini": {
+    "input": 1.5,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.38
+  },
+  "vercel/openai/gpt-3.5-turbo": {
+    "input": 0.5,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/gpt-3.5-turbo-instruct": {
+    "input": 1.5,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/gpt-4-turbo": {
+    "input": 10,
+    "output": 30,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/gpt-4.1": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "vercel/openai/gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "vercel/openai/gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "vercel/openai/gpt-4o": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "vercel/openai/gpt-4o-mini": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "vercel/openai/gpt-4o-mini-search-preview": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "vercel/openai/gpt-5-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "vercel/openai/gpt-5-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "vercel/openai/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.025
+  },
+  "vercel/openai/gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.005
+  },
+  "vercel/openai/gpt-5-pro": {
+    "input": 15,
+    "output": 120,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "vercel/openai/gpt-5.1-codex-max": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "vercel/openai/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "vercel/openai/gpt-5.1-instant": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "vercel/openai/gpt-5.1-thinking": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.13
+  },
+  "vercel/openai/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.18
+  },
+  "vercel/openai/gpt-5.2-chat": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.18
+  },
+  "vercel/openai/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "vercel/openai/gpt-5.2-pro": {
+    "input": 21,
+    "output": 168,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/gpt-5.3-chat": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "vercel/openai/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "vercel/openai/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "vercel/openai/gpt-5.4-mini": {
+    "input": 0.75,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "vercel/openai/gpt-5.4-nano": {
+    "input": 0.2,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "vercel/openai/gpt-5.4-pro": {
+    "input": 30,
+    "output": 180,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/gpt-oss-120b": {
+    "input": 0.1,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/gpt-oss-20b": {
+    "input": 0.07,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/gpt-oss-safeguard-20b": {
+    "input": 0.08,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.04
+  },
+  "vercel/openai/o1": {
+    "input": 15,
+    "output": 60,
+    "cacheWrite": 0,
+    "cacheRead": 7.5
+  },
+  "vercel/openai/o3": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.5
+  },
+  "vercel/openai/o3-deep-research": {
+    "input": 10,
+    "output": 40,
+    "cacheWrite": 0,
+    "cacheRead": 2.5
+  },
+  "vercel/openai/o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.55
+  },
+  "vercel/openai/o3-pro": {
+    "input": 20,
+    "output": 80,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.28
+  },
+  "vercel/openai/text-embedding-3-large": {
+    "input": 0.13,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/text-embedding-3-small": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/openai/text-embedding-ada-002": {
+    "input": 0.1,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/perplexity/sonar": {
+    "input": 1,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/perplexity/sonar-pro": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/perplexity/sonar-reasoning": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/perplexity/sonar-reasoning-pro": {
+    "input": 2,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/prime-intellect/intellect-3": {
+    "input": 0.2,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/vercel/v0-1.0-md": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/vercel/v0-1.5-md": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/voyage/voyage-3-large": {
+    "input": 0.18,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/voyage/voyage-3.5": {
+    "input": 0.06,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/voyage/voyage-3.5-lite": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/voyage/voyage-code-2": {
+    "input": 0.12,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/voyage/voyage-code-3": {
+    "input": 0.18,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/voyage/voyage-finance-2": {
+    "input": 0.12,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/voyage/voyage-law-2": {
+    "input": 0.12,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/xai/grok-2-vision": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "vercel/xai/grok-3": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
     "cacheRead": 0.75
   },
-  "x-ai/grok-4-fast": {
+  "vercel/xai/grok-3-fast": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "vercel/xai/grok-3-mini": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "vercel/xai/grok-3-mini-fast": {
+    "input": 0.6,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "vercel/xai/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "vercel/xai/grok-4-fast-non-reasoning": {
     "input": 0.2,
     "output": 0.5,
-    "cacheWrite": 0.05,
+    "cacheWrite": 0,
     "cacheRead": 0.05
   },
-  "x-ai/grok-4.1-fast": {
+  "vercel/xai/grok-4-fast-reasoning": {
     "input": 0.2,
     "output": 0.5,
-    "cacheWrite": 0.05,
+    "cacheWrite": 0,
     "cacheRead": 0.05
   },
-  "x-ai/grok-code-fast-1": {
+  "vercel/xai/grok-4.1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "vercel/xai/grok-4.1-fast-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "vercel/xai/grok-4.20-multi-agent": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vercel/xai/grok-4.20-multi-agent-beta": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vercel/xai/grok-4.20-non-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vercel/xai/grok-4.20-non-reasoning-beta": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vercel/xai/grok-4.20-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vercel/xai/grok-4.20-reasoning-beta": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vercel/xai/grok-code-fast-1": {
     "input": 0.2,
     "output": 1.5,
     "cacheWrite": 0,
     "cacheRead": 0.02
+  },
+  "vercel/xiaomi/mimo-v2-flash": {
+    "input": 0.1,
+    "output": 0.29,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/xiaomi/mimo-v2-pro": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vercel/zai/glm-4.5": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/zai/glm-4.5-air": {
+    "input": 0.2,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/zai/glm-4.5v": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/zai/glm-4.6": {
+    "input": 0.45,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/zai/glm-4.6v": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "vercel/zai/glm-4.7": {
+    "input": 0.43,
+    "output": 1.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
+  },
+  "vercel/zai/glm-4.7-flash": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vercel/zai/glm-4.7-flashx": {
+    "input": 0.06,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "vercel/zai/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vercel/zai/glm-5-turbo": {
+    "input": 1.2,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "vercel/zai/glm-5v-turbo": {
+    "input": 1.2,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "virtuoso-large": {
+    "input": 0.75,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vivgrid/deepseek-v3.2": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vivgrid/gemini-3.1-flash-lite-preview": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 1,
+    "cacheRead": 0.025
+  },
+  "vivgrid/gemini-3.1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vivgrid/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "vivgrid/gpt-5-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "vivgrid/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "vivgrid/gpt-5.1-codex-max": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.125
+  },
+  "vivgrid/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.175
+  },
+  "vivgrid/gpt-5.4": {
+    "input": 2.5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.25
+  },
+  "voyage-3-large": {
+    "input": 0.18,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "voyage-3.5": {
+    "input": 0.06,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "voyage-3.5-lite": {
+    "input": 0.02,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "voyage-code-2": {
+    "input": 0.12,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "voyage-code-3": {
+    "input": 0.18,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "voyage-finance-2": {
+    "input": 0.12,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "voyage-law-2": {
+    "input": 0.12,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vultr/deepseek-v3.2": {
+    "input": 0.55,
+    "output": 1.65,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vultr/glm-5-fp8": {
+    "input": 0.85,
+    "output": 3.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vultr/kimi-k2.5": {
+    "input": 0.55,
+    "output": 2.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "vultr/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/deepseek-ai/deepseek-v3.1": {
+    "input": 0.55,
+    "output": 1.65,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/meta-llama/llama-3.1-70b-instruct": {
+    "input": 0.8,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/meta-llama/llama-3.1-8b-instruct": {
+    "input": 0.22,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/meta-llama/llama-3.3-70b-instruct": {
+    "input": 0.71,
+    "output": 0.71,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/meta-llama/llama-4-scout-17b-16e-instruct": {
+    "input": 0.17,
+    "output": 0.66,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/microsoft/phi-4-mini-instruct": {
+    "input": 0.08,
+    "output": 0.35,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/minimaxai/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/moonshotai/kimi-k2.5": {
+    "input": 0.5,
+    "output": 2.85,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/nvidia/nvidia-nemotron-3-super-120b-a12b-fp8": {
+    "input": 0.2,
+    "output": 0.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/openai/gpt-oss-120b": {
+    "input": 0.15,
+    "output": 0.6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/openai/gpt-oss-20b": {
+    "input": 0.05,
+    "output": 0.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/openpipe/qwen3-14b-instruct": {
+    "input": 0.05,
+    "output": 0.22,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/qwen/qwen3-235b-a22b-instruct-2507": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/qwen/qwen3-235b-a22b-thinking-2507": {
+    "input": 0.1,
+    "output": 0.1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/qwen/qwen3-30b-a3b-instruct-2507": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": 1,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wandb/zai-org/glm-5-fp8": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "wayfarer-large-70b-llama-3.3": {
+    "input": 0.700000007,
+    "output": 0.700000007,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "weaver": {
+    "input": 0.75,
+    "output": 1,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "whisper-large-v3-turbo": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "writer.palmyra-x4-v1:0": {
+    "input": 2.5,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "writer.palmyra-x5-v1:0": {
+    "input": 0.6,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "xai/grok-2": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "xai/grok-2-1212": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "xai/grok-2-latest": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "xai/grok-2-vision": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "xai/grok-2-vision-1212": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "xai/grok-2-vision-latest": {
+    "input": 2,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 2
+  },
+  "xai/grok-3": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "xai/grok-3-fast": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "xai/grok-3-fast-latest": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 0,
+    "cacheRead": 1.25
+  },
+  "xai/grok-3-latest": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "xai/grok-3-mini": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "xai/grok-3-mini-fast": {
+    "input": 0.6,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "xai/grok-3-mini-fast-latest": {
+    "input": 0.6,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "xai/grok-3-mini-latest": {
+    "input": 0.3,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.075
+  },
+  "xai/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "xai/grok-4-1-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "xai/grok-4-1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "xai/grok-4-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "xai/grok-4-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "xai/grok-4.20-0309-non-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "xai/grok-4.20-0309-reasoning": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "xai/grok-4.20-multi-agent-0309": {
+    "input": 2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "xai/grok-beta": {
+    "input": 5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 5
+  },
+  "xai/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "xai/grok-vision-beta": {
+    "input": 5,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 5
+  },
+  "xiaomi-token-plan-ams/mimo-v2-omni": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "xiaomi-token-plan-ams/mimo-v2-pro": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "xiaomi-token-plan-ams/mimo-v2-tts": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "xiaomi-token-plan-cn/mimo-v2-omni": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "xiaomi-token-plan-cn/mimo-v2-pro": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "xiaomi-token-plan-cn/mimo-v2-tts": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "xiaomi-token-plan-sgp/mimo-v2-omni": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "xiaomi-token-plan-sgp/mimo-v2-pro": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "xiaomi-token-plan-sgp/mimo-v2-tts": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
   },
   "xiaomi/mimo-v2-flash": {
     "input": 0.1,
@@ -1907,51 +30065,33 @@
     "cacheWrite": 0,
     "cacheRead": 0.01
   },
-  "z-ai/glm-4.5": {
-    "input": 0.6,
-    "output": 2.2,
-    "cacheWrite": 0.11,
-    "cacheRead": 0
+  "xiaomi/mimo-v2-omni": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.08
   },
-  "z-ai/glm-4.5-air": {
-    "input": 0,
-    "output": 0,
+  "xiaomi/mimo-v2-pro": {
+    "input": 1,
+    "output": 3,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "yi-large": {
+    "input": 3.196,
+    "output": 3.196,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "z-ai/glm-4.5-air:free": {
-    "input": 0,
-    "output": 0,
+  "yi-lightning": {
+    "input": 0.2006,
+    "output": 0.2006,
     "cacheWrite": 0,
     "cacheRead": 0
   },
-  "z-ai/glm-4.5v": {
-    "input": 0.6,
-    "output": 1.8,
-    "cacheWrite": 0,
-    "cacheRead": 0
-  },
-  "z-ai/glm-4.6": {
-    "input": 0.6,
-    "output": 2.2,
-    "cacheWrite": 0.11,
-    "cacheRead": 0
-  },
-  "z-ai/glm-4.6:exacto": {
-    "input": 0.6,
-    "output": 1.9,
-    "cacheWrite": 0,
-    "cacheRead": 0.11
-  },
-  "z-ai/glm-4.7": {
-    "input": 0.6,
-    "output": 2.2,
-    "cacheWrite": 0,
-    "cacheRead": 0.11
-  },
-  "z-ai/glm-4.7-flash": {
-    "input": 0.07,
-    "output": 0.4,
+  "yi-medium-200k": {
+    "input": 2.499,
+    "output": 2.499,
     "cacheWrite": 0,
     "cacheRead": 0
   },
@@ -1962,6 +30102,12 @@
     "cacheRead": 0
   },
   "zai-coding-plan/glm-4.5-air": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai-coding-plan/glm-4.5-flash": {
     "input": 0,
     "output": 0,
     "cacheWrite": 0,
@@ -1990,5 +30136,845 @@
     "output": 0,
     "cacheWrite": 0,
     "cacheRead": 0
+  },
+  "zai-coding-plan/glm-4.7-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai-coding-plan/glm-4.7-flashx": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "zai-coding-plan/glm-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai-coding-plan/glm-5-turbo": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai-coding-plan/glm-5.1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai-coding-plan/glm-5v-turbo": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai-glm-4.7": {
+    "input": 2.25,
+    "output": 2.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai-glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "zai-org-glm-4.6": {
+    "input": 0.85,
+    "output": 2.75,
+    "cacheWrite": 0,
+    "cacheRead": 0.3
+  },
+  "zai-org-glm-4.7": {
+    "input": 0.55,
+    "output": 2.65,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "zai-org-glm-4.7-flash": {
+    "input": 0.125,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai-org-glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "zai.glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai.glm-4.7-flash": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai.glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai/glm-4.5": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "zai/glm-4.5-air": {
+    "input": 0.2,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "zai/glm-4.5-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai/glm-4.5v": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai/glm-4.6": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "zai/glm-4.6v": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "zai/glm-4.7-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zai/glm-4.7-flashx": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "zai/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "zai/glm-5-turbo": {
+    "input": 1.2,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "zai/glm-5v-turbo": {
+    "input": 1.2,
+    "output": 4,
+    "cacheWrite": 0,
+    "cacheRead": 0.24
+  },
+  "zenmux/anthropic/claude-3.5-haiku": {
+    "input": 0.8,
+    "output": 4,
+    "cacheWrite": 1,
+    "cacheRead": 0.08
+  },
+  "zenmux/anthropic/claude-3.7-sonnet": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "zenmux/anthropic/claude-haiku-4.5": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "zenmux/anthropic/claude-opus-4": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "zenmux/anthropic/claude-opus-4.1": {
+    "input": 15,
+    "output": 75,
+    "cacheWrite": 18.75,
+    "cacheRead": 1.5
+  },
+  "zenmux/anthropic/claude-opus-4.5": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "zenmux/anthropic/claude-opus-4.6": {
+    "input": 5,
+    "output": 25,
+    "cacheWrite": 6.25,
+    "cacheRead": 0.5
+  },
+  "zenmux/anthropic/claude-sonnet-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "zenmux/anthropic/claude-sonnet-4.5": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "zenmux/anthropic/claude-sonnet-4.6": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 3.75,
+    "cacheRead": 0.3
+  },
+  "zenmux/baidu/ernie-5.0-thinking-preview": {
+    "input": 0.84,
+    "output": 3.37,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/deepseek/deepseek-chat": {
+    "input": 0.28,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "zenmux/deepseek/deepseek-v3.2": {
+    "input": 0.28,
+    "output": 0.43,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/deepseek/deepseek-v3.2-exp": {
+    "input": 0.22,
+    "output": 0.33,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/google/gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cacheWrite": 1,
+    "cacheRead": 0.07
+  },
+  "zenmux/google/gemini-2.5-flash-lite": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 1,
+    "cacheRead": 0.03
+  },
+  "zenmux/google/gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 4.5,
+    "cacheRead": 0.31
+  },
+  "zenmux/google/gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 1,
+    "cacheRead": 0.05
+  },
+  "zenmux/google/gemini-3-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 4.5,
+    "cacheRead": 0.2
+  },
+  "zenmux/google/gemini-3.1-flash-lite-preview": {
+    "input": 0.25,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/google/gemini-3.1-pro-preview": {
+    "input": 2,
+    "output": 12,
+    "cacheWrite": 4.5,
+    "cacheRead": 0.2
+  },
+  "zenmux/inclusionai/ling-1t": {
+    "input": 0.56,
+    "output": 2.24,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "zenmux/inclusionai/ring-1t": {
+    "input": 0.56,
+    "output": 2.24,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "zenmux/kuaishou/kat-coder-pro-v1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "zenmux/kuaishou/kat-coder-pro-v1-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/kuaishou/kat-coder-pro-v2": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "zenmux/minimax/minimax-m2": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.38,
+    "cacheRead": 0.03
+  },
+  "zenmux/minimax/minimax-m2.1": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.38,
+    "cacheRead": 0.03
+  },
+  "zenmux/minimax/minimax-m2.5": {
+    "input": 0.3,
+    "output": 1.2,
+    "cacheWrite": 0.375,
+    "cacheRead": 0.03
+  },
+  "zenmux/minimax/minimax-m2.5-lightning": {
+    "input": 0.6,
+    "output": 4.8,
+    "cacheWrite": 0.75,
+    "cacheRead": 0.06
+  },
+  "zenmux/minimax/minimax-m2.7": {
+    "input": 0.3055,
+    "output": 1.2219,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/minimax/minimax-m2.7-highspeed": {
+    "input": 0.611,
+    "output": 2.4439,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/moonshotai/kimi-k2-0905": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "zenmux/moonshotai/kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "zenmux/moonshotai/kimi-k2-thinking-turbo": {
+    "input": 1.15,
+    "output": 8,
+    "cacheWrite": 0,
+    "cacheRead": 0.15
+  },
+  "zenmux/moonshotai/kimi-k2.5": {
+    "input": 0.58,
+    "output": 3.02,
+    "cacheWrite": 0,
+    "cacheRead": 0.1
+  },
+  "zenmux/openai/gpt-5": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.12
+  },
+  "zenmux/openai/gpt-5-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.12
+  },
+  "zenmux/openai/gpt-5.1": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.12
+  },
+  "zenmux/openai/gpt-5.1-chat": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.12
+  },
+  "zenmux/openai/gpt-5.1-codex": {
+    "input": 1.25,
+    "output": 10,
+    "cacheWrite": 0,
+    "cacheRead": 0.12
+  },
+  "zenmux/openai/gpt-5.1-codex-mini": {
+    "input": 0.25,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "zenmux/openai/gpt-5.2": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.17
+  },
+  "zenmux/openai/gpt-5.2-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0.17
+  },
+  "zenmux/openai/gpt-5.2-pro": {
+    "input": 21,
+    "output": 168,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/openai/gpt-5.3-chat": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/openai/gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/openai/gpt-5.4": {
+    "input": 3.75,
+    "output": 18.75,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/openai/gpt-5.4-mini": {
+    "input": 0.75,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/openai/gpt-5.4-nano": {
+    "input": 0.2,
+    "output": 1.25,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/openai/gpt-5.4-pro": {
+    "input": 45,
+    "output": 225,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/qwen/qwen3-coder-plus": {
+    "input": 1,
+    "output": 5,
+    "cacheWrite": 1.25,
+    "cacheRead": 0.1
+  },
+  "zenmux/qwen/qwen3-max": {
+    "input": 1.2,
+    "output": 6,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/qwen/qwen3.5-flash": {
+    "input": 0.1,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/qwen/qwen3.5-plus": {
+    "input": 0.8,
+    "output": 4.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/qwen/qwen3.6-plus": {
+    "input": 0.5,
+    "output": 3,
+    "cacheWrite": 0.625,
+    "cacheRead": 0.05
+  },
+  "zenmux/stepfun/step-3": {
+    "input": 0.21,
+    "output": 0.57,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/stepfun/step-3.5-flash": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/stepfun/step-3.5-flash-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/volcengine/doubao-seed-1.8": {
+    "input": 0.11,
+    "output": 0.28,
+    "cacheWrite": 0.0024,
+    "cacheRead": 0.02
+  },
+  "zenmux/volcengine/doubao-seed-2.0-code": {
+    "input": 0.9,
+    "output": 4.48,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/volcengine/doubao-seed-2.0-lite": {
+    "input": 0.09,
+    "output": 0.51,
+    "cacheWrite": 0.0024,
+    "cacheRead": 0.02
+  },
+  "zenmux/volcengine/doubao-seed-2.0-mini": {
+    "input": 0.03,
+    "output": 0.28,
+    "cacheWrite": 0.0024,
+    "cacheRead": 0.01
+  },
+  "zenmux/volcengine/doubao-seed-2.0-pro": {
+    "input": 0.45,
+    "output": 2.24,
+    "cacheWrite": 0.0024,
+    "cacheRead": 0.09
+  },
+  "zenmux/volcengine/doubao-seed-code": {
+    "input": 0.17,
+    "output": 1.12,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "zenmux/x-ai/grok-4": {
+    "input": 3,
+    "output": 15,
+    "cacheWrite": 0,
+    "cacheRead": 0.75
+  },
+  "zenmux/x-ai/grok-4-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "zenmux/x-ai/grok-4.1-fast": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "zenmux/x-ai/grok-4.1-fast-non-reasoning": {
+    "input": 0.2,
+    "output": 0.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.05
+  },
+  "zenmux/x-ai/grok-4.2-fast": {
+    "input": 3,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/x-ai/grok-4.2-fast-non-reasoning": {
+    "input": 3,
+    "output": 9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/x-ai/grok-code-fast-1": {
+    "input": 0.2,
+    "output": 1.5,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "zenmux/xiaomi/mimo-v2-flash": {
+    "input": 0.1,
+    "output": 0.3,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "zenmux/xiaomi/mimo-v2-flash-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/xiaomi/mimo-v2-omni": {
+    "input": 0.4,
+    "output": 2,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/xiaomi/mimo-v2-pro": {
+    "input": 1.5,
+    "output": 4.5,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/z-ai/glm-4.5": {
+    "input": 0.35,
+    "output": 1.54,
+    "cacheWrite": 0,
+    "cacheRead": 0.07
+  },
+  "zenmux/z-ai/glm-4.5-air": {
+    "input": 0.11,
+    "output": 0.56,
+    "cacheWrite": 0,
+    "cacheRead": 0.02
+  },
+  "zenmux/z-ai/glm-4.6": {
+    "input": 0.35,
+    "output": 1.54,
+    "cacheWrite": 0,
+    "cacheRead": 0.07
+  },
+  "zenmux/z-ai/glm-4.6v": {
+    "input": 0.14,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "zenmux/z-ai/glm-4.6v-flash": {
+    "input": 0.02,
+    "output": 0.21,
+    "cacheWrite": 0,
+    "cacheRead": 0.0043
+  },
+  "zenmux/z-ai/glm-4.6v-flash-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/z-ai/glm-4.7": {
+    "input": 0.28,
+    "output": 1.14,
+    "cacheWrite": 0,
+    "cacheRead": 0.06
+  },
+  "zenmux/z-ai/glm-4.7-flash-free": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/z-ai/glm-4.7-flashx": {
+    "input": 0.07,
+    "output": 0.42,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "zenmux/z-ai/glm-5": {
+    "input": 0.58,
+    "output": 2.6,
+    "cacheWrite": 0,
+    "cacheRead": 0.14
+  },
+  "zenmux/z-ai/glm-5-turbo": {
+    "input": 0.88,
+    "output": 3.48,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zenmux/z-ai/glm-5v-turbo": {
+    "input": 0.726,
+    "output": 3.1946,
+    "cacheWrite": 0,
+    "cacheRead": 0.1743
+  },
+  "zhipuai-coding-plan/glm-4.5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-4.5-air": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-4.5-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-4.5v": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-4.6": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-4.6v": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-4.6v-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-4.7": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-4.7-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-4.7-flashx": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "zhipuai-coding-plan/glm-5": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-5-turbo": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-5.1": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai-coding-plan/glm-5v-turbo": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai/glm-4.5": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "zhipuai/glm-4.5-air": {
+    "input": 0.2,
+    "output": 1.1,
+    "cacheWrite": 0,
+    "cacheRead": 0.03
+  },
+  "zhipuai/glm-4.5-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai/glm-4.5v": {
+    "input": 0.6,
+    "output": 1.8,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai/glm-4.6": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "zhipuai/glm-4.6v": {
+    "input": 0.3,
+    "output": 0.9,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai/glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.11
+  },
+  "zhipuai/glm-4.7-flash": {
+    "input": 0,
+    "output": 0,
+    "cacheWrite": 0,
+    "cacheRead": 0
+  },
+  "zhipuai/glm-4.7-flashx": {
+    "input": 0.07,
+    "output": 0.4,
+    "cacheWrite": 0,
+    "cacheRead": 0.01
+  },
+  "zhipuai/glm-5": {
+    "input": 1,
+    "output": 3.2,
+    "cacheWrite": 0,
+    "cacheRead": 0.2
+  },
+  "zhipuai/glm-5v-turbo": {
+    "input": 5,
+    "output": 22,
+    "cacheWrite": 0,
+    "cacheRead": 1.2
   }
 }

--- a/plugin/tokenscope-lib/config.ts
+++ b/plugin/tokenscope-lib/config.ts
@@ -2,11 +2,16 @@
 
 import path from "path"
 import fs from "fs/promises"
+import { homedir } from "os"
 import { fileURLToPath } from "url"
 import type { TokenizerSpec, ModelPricing, TokenscopeConfig } from "./types"
 
 export const DEFAULT_ENTRY_LIMIT = 3
-export const VENDOR_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "vendor", "node_modules")
+const PACKAGE_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..")
+const BUNDLED_TOKENSCOPE_CONFIG_PATH = path.join(PACKAGE_ROOT, "tokenscope-config.json")
+const USER_TOKENSCOPE_CONFIG_PATH = path.join(homedir(), ".config", "opencode", "tokenscope-config.json")
+
+export const VENDOR_ROOT = path.join(PACKAGE_ROOT, "vendor", "node_modules")
 
 // Pricing cache
 let PRICING_CACHE: Record<string, ModelPricing> | null = null
@@ -15,7 +20,7 @@ export async function loadModelPricing(): Promise<Record<string, ModelPricing>> 
   if (PRICING_CACHE) return PRICING_CACHE
 
   try {
-    const modelsPath = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "models.json")
+    const modelsPath = path.join(PACKAGE_ROOT, "models.json")
     const data = await fs.readFile(modelsPath, "utf8")
     PRICING_CACHE = JSON.parse(data)
     return PRICING_CACHE!
@@ -37,19 +42,28 @@ export const DEFAULT_TOKENSCOPE_CONFIG: TokenscopeConfig = {
 
 let TOKENSCOPE_CONFIG_CACHE: TokenscopeConfig | null = null
 
+async function readTokenscopeConfigFile(configPath: string): Promise<Partial<TokenscopeConfig> | null> {
+  try {
+    const data = await fs.readFile(configPath, "utf8")
+    return JSON.parse(data) as Partial<TokenscopeConfig>
+  } catch {
+    return null
+  }
+}
+
 export async function loadTokenscopeConfig(): Promise<TokenscopeConfig> {
   if (TOKENSCOPE_CONFIG_CACHE) return TOKENSCOPE_CONFIG_CACHE
 
-  try {
-    const configPath = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "tokenscope-config.json")
-    const data = await fs.readFile(configPath, "utf8")
-    const config = { ...DEFAULT_TOKENSCOPE_CONFIG, ...JSON.parse(data) }
-    TOKENSCOPE_CONFIG_CACHE = config
-    return config
-  } catch {
-    TOKENSCOPE_CONFIG_CACHE = DEFAULT_TOKENSCOPE_CONFIG
-    return DEFAULT_TOKENSCOPE_CONFIG
+  const userConfig = await readTokenscopeConfigFile(USER_TOKENSCOPE_CONFIG_PATH)
+  const bundledConfig = userConfig ? null : await readTokenscopeConfigFile(BUNDLED_TOKENSCOPE_CONFIG_PATH)
+
+  TOKENSCOPE_CONFIG_CACHE = {
+    ...DEFAULT_TOKENSCOPE_CONFIG,
+    ...(bundledConfig ?? {}),
+    ...(userConfig ?? {}),
   }
+
+  return TOKENSCOPE_CONFIG_CACHE
 }
 
 // OpenAI model mapping for tiktoken

--- a/plugin/tokenscope-lib/cost.ts
+++ b/plugin/tokenscope-lib/cost.ts
@@ -6,7 +6,7 @@ export class CostCalculator {
   constructor(private pricingData: Record<string, ModelPricing>) {}
 
   calculateCost(analysis: TokenAnalysis): CostEstimate {
-    const pricing = this.getPricing(analysis.model.name)
+    const pricing = this.getPricing(analysis.pricingModelName ?? analysis.model.name)
     const hasActivity = analysis.apiCallCount > 0 && (analysis.inputTokens > 0 || analysis.outputTokens > 0)
     const isSubscription = hasActivity && analysis.sessionCost === 0
 
@@ -38,33 +38,55 @@ export class CostCalculator {
     }
   }
 
+  buildLookupKey(providerID?: string, modelID?: string): string {
+    const provider = providerID?.trim()
+    const model = modelID?.trim()
+
+    if (!provider) return model ?? ""
+    if (!model) return provider
+
+    const normalizedProvider = provider.toLowerCase()
+    const normalizedModel = model.toLowerCase()
+    if (normalizedModel.startsWith(`${normalizedProvider}/`)) return model
+
+    return `${provider}/${model}`
+  }
+
   getPricing(modelName: string): ModelPricing {
-    const normalizedName = this.normalizeModelName(modelName)
-
-    if (this.pricingData[normalizedName]) return this.pricingData[normalizedName]
-
-    const lowerModel = normalizedName.toLowerCase()
-    for (const [key, pricing] of Object.entries(this.pricingData)) {
-      if (lowerModel.startsWith(key.toLowerCase())) return pricing
-    }
-
-    return this.pricingData["default"] || { input: 1, output: 3, cacheWrite: 0, cacheRead: 0 }
+    return this.findPricing(modelName) ?? this.pricingData["default"] ?? { input: 1, output: 3, cacheWrite: 0, cacheRead: 0 }
   }
 
   hasPricing(modelName: string): boolean {
-    const normalizedName = this.normalizeModelName(modelName)
+    return this.findPricing(modelName) !== undefined
+  }
 
-    if (this.pricingData[normalizedName]) return true
+  private findPricing(modelName: string): ModelPricing | undefined {
+    const rawName = modelName.trim().toLowerCase()
+    if (!rawName) return undefined
 
-    const lowerModel = normalizedName.toLowerCase()
-    for (const key of Object.keys(this.pricingData)) {
-      if (lowerModel.startsWith(key.toLowerCase())) return true
+    if (this.pricingData[rawName]) return this.pricingData[rawName]
+
+    const normalizedName = this.normalizeModelName(rawName)
+    if (this.pricingData[normalizedName]) return this.pricingData[normalizedName]
+
+    return this.findLongestPrefixMatch(rawName) ?? this.findLongestPrefixMatch(normalizedName)
+  }
+
+  private findLongestPrefixMatch(modelName: string): ModelPricing | undefined {
+    let bestMatchLength = -1
+    let bestPricing: ModelPricing | undefined
+
+    for (const [key, pricing] of Object.entries(this.pricingData)) {
+      if (modelName.startsWith(key.toLowerCase()) && key.length > bestMatchLength) {
+        bestMatchLength = key.length
+        bestPricing = pricing
+      }
     }
 
-    return false
+    return bestPricing
   }
 
   private normalizeModelName(modelName: string): string {
-    return modelName.includes("/") ? modelName.split("/").pop() || modelName : modelName
+    return modelName.includes("/") ? modelName.split("/").pop()?.trim().toLowerCase() || modelName : modelName.trim().toLowerCase()
   }
 }

--- a/plugin/tokenscope-lib/subagent.ts
+++ b/plugin/tokenscope-lib/subagent.ts
@@ -87,6 +87,7 @@ export class SubagentAnalyzer {
         assistantMessageCount = 0,
         telemetryApiCalls = 0,
         stepFinishCount = 0,
+        providerID = "",
         modelName = "unknown"
 
       for (const message of messages) {
@@ -112,6 +113,7 @@ export class SubagentAnalyzer {
             cacheWriteTokens += Number(tokens.cache?.write) || 0
           }
           apiCost += Number(message.info.cost) || 0
+          if (message.info.providerID) providerID = message.info.providerID
           if (message.info.modelID) modelName = message.info.modelID
         }
       }
@@ -119,7 +121,8 @@ export class SubagentAnalyzer {
       const apiCallCount = stepFinishCount > 0 ? stepFinishCount : telemetryApiCalls
 
       const totalTokens = inputTokens + outputTokens + reasoningTokens + cacheReadTokens + cacheWriteTokens
-      const pricing = this.costCalculator.getPricing(modelName)
+      const pricingModelName = this.costCalculator.buildLookupKey(providerID, modelName) || modelName
+      const pricing = this.costCalculator.getPricing(pricingModelName)
       const estimatedCost =
         (inputTokens / 1_000_000) * pricing.input +
         ((outputTokens + reasoningTokens) / 1_000_000) * pricing.output +

--- a/plugin/tokenscope-lib/types.ts
+++ b/plugin/tokenscope-lib/types.ts
@@ -59,6 +59,7 @@ export interface CategorySummary {
 export interface TokenAnalysis {
   sessionID: string
   model: TokenModel
+  pricingModelName?: string
   categories: {
     system: CategorySummary
     user: CategorySummary

--- a/plugin/tokenscope.ts
+++ b/plugin/tokenscope.ts
@@ -116,6 +116,7 @@ export const TokenAnalyzerPlugin: Plugin = async ({ client }) => {
             }
 
             const { model: tokenModel, providerID, modelID } = modelResolver.resolveModelAndProvider(messages)
+            const pricingModelName = costCalculator.buildLookupKey(providerID, modelID) || tokenModel.name
 
             if (tokenModel.spec.kind === "approx") {
               warnings.add(
@@ -124,10 +125,10 @@ export const TokenAnalyzerPlugin: Plugin = async ({ client }) => {
               )
             }
 
-            if (!costCalculator.hasPricing(tokenModel.name)) {
+            if (!costCalculator.hasPricing(pricingModelName)) {
               warnings.add(
-                `Pricing for '${tokenModel.name}' was not found in models.json. Cost estimates use the default fallback rates ($1/M input, $3/M output, no cache pricing).`,
-                `missing-pricing:${tokenModel.name}`
+                `Pricing for '${pricingModelName}' was not found in models.json. Cost estimates use the default fallback rates ($1/M input, $3/M output, no cache pricing).`,
+                `missing-pricing:${pricingModelName}`
               )
             }
 
@@ -137,6 +138,7 @@ export const TokenAnalyzerPlugin: Plugin = async ({ client }) => {
               tokenModel,
               args.limitMessages ?? DEFAULT_ENTRY_LIMIT
             )
+            analysis.pricingModelName = pricingModelName
 
             // Subagent analysis (respects config)
             const shouldIncludeSubagents = args.includeSubagents !== false && config.enableSubagentAnalysis
@@ -145,7 +147,7 @@ export const TokenAnalyzerPlugin: Plugin = async ({ client }) => {
             }
 
             // Context analysis (context breakdown, tool estimates, cache efficiency)
-            const pricing = costCalculator.getPricing(tokenModel.name)
+            const pricing = costCalculator.getPricing(pricingModelName)
             const contextResult = await contextAnalyzer.analyze(sessionID, tokenModel, pricing, config)
 
             // Merge context analysis results into main analysis


### PR DESCRIPTION
## Summary
- sync `plugin/models.json` from the current `models.dev` API
- expand pricing coverage to exact provider/model entries and preserve safe alias lookups
- make cost lookup provider-aware for main sessions and subagents
- update README wording to reflect models.dev-backed pricing data

## Validation
- `cd plugin && npm run build`