### PR TITLE
Fix OpenCode core drift in TokenScope

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -153,7 +153,7 @@ cat token-usage-output.txt
 - **Configurable Sections**: Enable/disable analysis features via `tokenscope-config.json`
 
 ### Skill Analysis
-- **Available Skills**: Shows all skills listed in the skill tool definition with their token cost
+- **Available Skills**: Shows the always-available skill catalog token cost (including the verbose system-prompt catalog OpenCode injects on every API call)
 - **Available Subagents**: Shows all subagents listed in the Task tool definition with their token cost
 - **Loaded Skills**: Tracks skills loaded during the session with call counts
 - **Cumulative Token Tracking**: Accurately counts token cost when skills are called multiple times
@@ -164,11 +164,13 @@ This section explains how OpenCode handles skills and why the token counting wor
 
 ### How Skills Work
 
-Skills are on-demand instructions that agents can load via the `skill` tool. They have two token consumption points:
+Skills are on-demand instructions that agents can load via the `skill` tool. They have multiple token consumption points:
 
-1. **Available Skills List**: Skill names and descriptions are embedded in the `skill` tool's description as XML. This is part of the system prompt and costs tokens on **every API call**.
+1. **Always-Available Skill Catalog**: Current OpenCode versions inject a verbose XML skill catalog into the system prompt on **every API call**.
 
-2. **Loaded Skill Content**: When an agent calls `skill({ name: "my-skill" })`, the full SKILL.md content is loaded and returned as a tool result.
+2. **Skill Tool Description**: The `skill` tool also includes a compact markdown list of available skills in its tool description, which also consumes tokens on every API call.
+
+3. **Loaded Skill Content**: When an agent calls `skill({ name: "my-skill" })`, the full SKILL.md content is loaded and returned as a tool result.
 
 ### Why Multiple Skill Calls Multiply Token Cost
 

--- a/plugin/tokenscope-lib/analyzer.ts
+++ b/plugin/tokenscope-lib/analyzer.ts
@@ -30,13 +30,16 @@ export class ModelResolver {
     let detectedModelID = "claude-sonnet-4-20250514"
 
     for (const message of [...messages].reverse()) {
-      if (message.info.providerID) {
-        detectedProviderID = this.canonicalize(message.info.providerID) || detectedProviderID
+      const providerID = this.getProviderID(message)
+      const modelID = this.getModelID(message)
+
+      if (providerID) {
+        detectedProviderID = this.canonicalize(providerID) || detectedProviderID
       }
-      if (message.info.modelID) {
-        detectedModelID = message.info.modelID
+      if (modelID) {
+        detectedModelID = modelID
       }
-      if (message.info.providerID && message.info.modelID) {
+      if (providerID && modelID) {
         break
       }
     }
@@ -52,8 +55,8 @@ export class ModelResolver {
 
   resolveTokenModel(messages: SessionMessage[]): TokenModel {
     for (const message of [...messages].reverse()) {
-      const modelID = this.canonicalize(message.info.modelID)
-      const providerID = this.canonicalize(message.info.providerID)
+      const modelID = this.canonicalize(this.getModelID(message))
+      const providerID = this.canonicalize(this.getProviderID(message))
 
       const openaiModel = this.resolveOpenAIModel(modelID, providerID)
       if (openaiModel) return openaiModel
@@ -113,6 +116,14 @@ export class ModelResolver {
   private mapOpenAI(modelID?: string): string {
     if (!modelID) return "cl100k_base"
     return OPENAI_MODEL_MAP[modelID] ?? modelID
+  }
+
+  private getProviderID(message: SessionMessage): string | undefined {
+    return message.info.providerID ?? message.info.model?.providerID
+  }
+
+  private getModelID(message: SessionMessage): string | undefined {
+    return message.info.modelID ?? message.info.model?.modelID
   }
 
   private canonicalize(value?: string): string | undefined {

--- a/plugin/tokenscope-lib/formatter.ts
+++ b/plugin/tokenscope-lib/formatter.ts
@@ -603,46 +603,61 @@ export class OutputFormatter {
   private formatAvailableSkills(analysis: SkillAnalysis): string[] {
     const lines: string[] = []
     const total = analysis.totalAvailableTokens
+    const hasSystemPromptCatalog = analysis.availableSkillsContextTokens > 0
 
     lines.push(``)
-    lines.push(`\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550`)
-    lines.push(`AVAILABLE SKILLS (in tool definitions)`)
-    lines.push(`\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`)
+    lines.push(`══════════════════════════════════════════════════════════════════════════`)
+    lines.push(`AVAILABLE SKILLS (always-available context)`)
+    lines.push(`─────────────────────────────────────────────────────────────────────────`)
     lines.push(``)
-    lines.push(`These skills are listed in the skill tool description and consume tokens on every API call.`)
+    if (hasSystemPromptCatalog) {
+      lines.push(`OpenCode currently includes a verbose skill catalog in the system prompt on every API call.`)
+      lines.push(`The rows below estimate the per-skill XML entries inside that shared catalog.`)
+    } else {
+      lines.push(`These skills were recovered from the skill tool metadata available to this session.`)
+    }
     lines.push(``)
 
-    // Header
     const nameHeader = "Skill".padEnd(this.SKILL_NAME_WIDTH)
     const descHeader = "Description".padEnd(this.SKILL_DESC_WIDTH)
     lines.push(`  ${nameHeader} ${descHeader} Tokens`)
-    lines.push(`  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`)
+    lines.push(`  ───────────────────────────────────────────────────────────────────────`)
 
-    // Sort by tokens descending
     const sortedSkills = [...analysis.availableSkills].sort((a, b) => b.tokens - a.tokens)
 
     for (const skill of sortedSkills) {
       const name =
         skill.name.length > this.SKILL_NAME_WIDTH
-          ? skill.name.substring(0, this.SKILL_NAME_WIDTH - 1) + "\u2026"
+          ? skill.name.substring(0, this.SKILL_NAME_WIDTH - 1) + "…"
           : skill.name.padEnd(this.SKILL_NAME_WIDTH)
 
       const desc =
         skill.description.length > this.SKILL_DESC_WIDTH
-          ? skill.description.substring(0, this.SKILL_DESC_WIDTH - 1) + "\u2026"
+          ? skill.description.substring(0, this.SKILL_DESC_WIDTH - 1) + "…"
           : skill.description.padEnd(this.SKILL_DESC_WIDTH)
 
       const tokens = `~${this.formatNumber(skill.tokens)}`.padStart(7)
-
       lines.push(`  ${name} ${desc} ${tokens}`)
     }
 
-    lines.push(`  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`)
+    lines.push(`  ───────────────────────────────────────────────────────────────────────`)
     lines.push(`  Total: ~${this.formatNumber(total)} tokens (${analysis.availableSkills.length} skills available)`)
     lines.push(``)
-    lines.push(
-      `  Note: Full skill tool description is ~${this.formatNumber(analysis.skillToolDescriptionTokens)} tokens (includes boilerplate).`
-    )
+
+    if (hasSystemPromptCatalog) {
+      lines.push(
+        `  Note: Full system-prompt skill catalog is ~${this.formatNumber(analysis.availableSkillsContextTokens)} tokens (includes shared wrapper/preamble).`
+      )
+      if (analysis.skillToolDescriptionTokens > 0) {
+        lines.push(
+          `        Compact skill tool description adds ~${this.formatNumber(analysis.skillToolDescriptionTokens)} tokens more.`
+        )
+      }
+    } else if (analysis.skillToolDescriptionTokens > 0) {
+      lines.push(
+        `  Note: Full skill tool description is ~${this.formatNumber(analysis.skillToolDescriptionTokens)} tokens (includes boilerplate).`
+      )
+    }
 
     return lines
   }

--- a/plugin/tokenscope-lib/opencode.ts
+++ b/plugin/tokenscope-lib/opencode.ts
@@ -1,0 +1,23 @@
+// OpenCode SDK compatibility helpers
+
+export async function fetchSessionMessages(client: any, sessionID: string): Promise<any> {
+  try {
+    return await client.session.messages({ path: { id: sessionID } })
+  } catch (error) {
+    if (!client?.session?.messages) throw error
+    return await client.session.messages({ path: { sessionID } })
+  }
+}
+
+export async function fetchSessionChildren(client: any, sessionID: string): Promise<any> {
+  try {
+    return await client.session.children({ path: { id: sessionID } })
+  } catch (error) {
+    if (!client?.session?.children) throw error
+    return await client.session.children({ path: { sessionID } })
+  }
+}
+
+export function unwrapResponseData<T>(response: any): T {
+  return ((response as any)?.data ?? response) as T
+}

--- a/plugin/tokenscope-lib/skill.ts
+++ b/plugin/tokenscope-lib/skill.ts
@@ -1,5 +1,7 @@
 // SkillAnalyzer - analyzes skill usage and token consumption
 
+import { pathToFileURL } from "url"
+
 import type {
   SessionMessage,
   SkillAnalysis,
@@ -13,10 +15,42 @@ import { isToolPart } from "./types"
 import { TokenizerManager } from "./tokenizer"
 import { WarningCollector, formatErrorMessage } from "./warnings"
 
+interface ToolListItem {
+  id: string
+  description?: string
+}
+
+interface PermissionRule {
+  permission: string
+  pattern: string
+  action: "allow" | "deny" | "ask"
+}
+
+interface RemoteAgent {
+  name: string
+  description?: string
+  mode?: string
+  permission?: unknown
+}
+
+interface RemoteSkill {
+  name: string
+  description: string
+  location?: string
+}
+
+interface ParsedSkillEntry {
+  name: string
+  description: string
+  rawText: string
+}
+
 export class SkillAnalyzer {
   constructor(
     private client: any,
     private tokenizerManager: TokenizerManager,
+    private serverUrl: URL,
+    private directory: string,
     private warnings?: WarningCollector
   ) {}
 
@@ -41,21 +75,27 @@ export class SkillAnalyzer {
       totalAvailableTokens: 0,
       totalAvailableSubagentTokens: 0,
       totalLoadedTokens: 0,
+      availableSkillsContextTokens: 0,
       skillToolDescriptionTokens: 0,
       taskToolDescriptionTokens: 0,
     }
 
     try {
       const tools = await this.listTools(providerID, modelID)
+      const [agents, skills] = await Promise.all([this.fetchAgents(), this.fetchSkills()])
+      const currentAgent = this.resolveCurrentAgent(messages, agents)
+      const accessibleSkills = this.filterAccessibleSkills(skills, currentAgent)
+      const accessibleSubagents = this.filterAccessibleSubagents(agents, currentAgent)
 
-      // 1. Get available skills from tool.list() API
-      const availableResult = await this.getAvailableSkills(tools, tokenModel)
+      // 1. Get available skills from current OpenCode catalogs / tool metadata
+      const availableResult = await this.getAvailableSkills(tools, accessibleSkills, tokenModel)
       result.availableSkills = availableResult.skills
       result.totalAvailableTokens = availableResult.totalTokens
+      result.availableSkillsContextTokens = availableResult.contextTokens
       result.skillToolDescriptionTokens = availableResult.descriptionTokens
 
-      // 2. Get available subagents from task tool description
-      const subagentResult = await this.getAvailableSubagents(tools, tokenModel)
+      // 2. Get available subagents from current OpenCode catalogs / task tool description
+      const subagentResult = await this.getAvailableSubagents(tools, accessibleSubagents, tokenModel)
       result.availableSubagents = subagentResult.subagents
       result.totalAvailableSubagentTokens = subagentResult.totalTokens
       result.taskToolDescriptionTokens = subagentResult.descriptionTokens
@@ -74,7 +114,7 @@ export class SkillAnalyzer {
   /**
    * Fetch current tool definitions for the provider/model
    */
-  private async listTools(providerID: string, modelID: string): Promise<any[]> {
+  private async listTools(providerID: string, modelID: string): Promise<ToolListItem[]> {
     try {
       const response = await this.client.tool.list({
         query: {
@@ -83,7 +123,8 @@ export class SkillAnalyzer {
         },
       })
 
-      return (response as any)?.data ?? response ?? []
+      const tools = (response as any)?.data ?? response ?? []
+      return Array.isArray(tools) ? (tools as ToolListItem[]) : []
     } catch (error) {
       this.warnings?.add(
         `Could not fetch tool metadata for ${providerID}/${modelID}. Skill and subagent catalog sections were skipped: ${formatErrorMessage(error)}`,
@@ -94,35 +135,52 @@ export class SkillAnalyzer {
   }
 
   /**
-   * Fetch available skills from the tool.list() API and parse them
+   * Fetch available skills from current OpenCode APIs when possible.
+   * Falls back to parsing the tool description for older versions.
    */
   private async getAvailableSkills(
-    tools: any[],
+    tools: ToolListItem[],
+    availableSkills: RemoteSkill[] | undefined,
     tokenModel: TokenModel
-  ): Promise<{ skills: AvailableSkill[]; totalTokens: number; descriptionTokens: number }> {
+  ): Promise<{ skills: AvailableSkill[]; totalTokens: number; contextTokens: number; descriptionTokens: number }> {
     const skills: AvailableSkill[] = []
     let totalTokens = 0
+    let contextTokens = 0
     let descriptionTokens = 0
 
     try {
-      // Find the skill tool
-      const skillTool = tools.find((t: any) => t.id === "skill")
-      if (!skillTool || !skillTool.description) {
-        return { skills, totalTokens, descriptionTokens }
+      if (availableSkills) {
+        const sortedSkills = [...availableSkills].sort((a, b) => a.name.localeCompare(b.name))
+        const skillToolDescription = this.buildSkillToolDescription(sortedSkills)
+        descriptionTokens = await this.tokenizerManager.countTokens(skillToolDescription, tokenModel)
+
+        const systemPromptCatalog = this.buildSkillSystemPrompt(sortedSkills)
+        contextTokens = await this.tokenizerManager.countTokens(systemPromptCatalog, tokenModel)
+
+        for (const skill of sortedSkills) {
+          const entry = this.buildVerboseSkillEntry(skill)
+          const tokens = await this.tokenizerManager.countTokens(entry, tokenModel)
+          skills.push({
+            name: skill.name,
+            description: skill.description,
+            tokens,
+          })
+          totalTokens += tokens
+        }
+
+        return { skills, totalTokens, contextTokens, descriptionTokens }
       }
 
-      // Tokenize the full skill tool description
+      const skillTool = tools.find((t) => t.id === "skill")
+      if (!skillTool?.description) {
+        return { skills, totalTokens, contextTokens, descriptionTokens }
+      }
+
       descriptionTokens = await this.tokenizerManager.countTokens(skillTool.description, tokenModel)
+      const parsedSkills = this.parseAvailableSkills(skillTool.description)
 
-      // Parse the <available_skills> XML from the description
-      const parsedSkills = this.parseAvailableSkillsXml(skillTool.description)
-
-      // Tokenize each skill's contribution
       for (const skill of parsedSkills) {
-        // Reconstruct the XML for this skill to get accurate token count
-        const skillXml = `  <skill>    <name>${skill.name}</name>    <description>${skill.description}</description>  </skill>`
-        const tokens = await this.tokenizerManager.countTokens(skillXml, tokenModel)
-
+        const tokens = await this.tokenizerManager.countTokens(skill.rawText, tokenModel)
         skills.push({
           name: skill.name,
           description: skill.description,
@@ -131,20 +189,19 @@ export class SkillAnalyzer {
         totalTokens += tokens
       }
     } catch (error) {
-      this.warnings?.add(
-        `Available skill estimates were skipped: ${formatErrorMessage(error)}`,
-        "available-skills"
-      )
+      this.warnings?.add(`Available skill estimates were skipped: ${formatErrorMessage(error)}`, "available-skills")
     }
 
-    return { skills, totalTokens, descriptionTokens }
+    return { skills, totalTokens, contextTokens, descriptionTokens }
   }
 
   /**
-   * Parse available subagents from task tool description
+   * Fetch available subagents from current OpenCode APIs when possible.
+   * Falls back to parsing the task tool description for older versions.
    */
   private async getAvailableSubagents(
-    tools: any[],
+    tools: ToolListItem[],
+    availableSubagents: RemoteAgent[] | undefined,
     tokenModel: TokenModel
   ): Promise<{ subagents: AvailableSubagent[]; totalTokens: number; descriptionTokens: number }> {
     const subagents: AvailableSubagent[] = []
@@ -152,8 +209,31 @@ export class SkillAnalyzer {
     let descriptionTokens = 0
 
     try {
-      const taskTool = tools.find((t: any) => t.id === "task")
-      if (!taskTool || !taskTool.description) {
+      const taskTool = tools.find((t) => t.id === "task")
+
+      if (availableSubagents) {
+        const sortedSubagents = [...availableSubagents].sort((a, b) => a.name.localeCompare(b.name))
+
+        if (taskTool?.description) {
+          const filteredDescription = this.buildFilteredTaskDescription(taskTool.description, sortedSubagents)
+          descriptionTokens = await this.tokenizerManager.countTokens(filteredDescription, tokenModel)
+        }
+
+        for (const subagent of sortedSubagents) {
+          const rawText = this.buildSubagentBullet(subagent)
+          const tokens = await this.tokenizerManager.countTokens(rawText, tokenModel)
+          subagents.push({
+            name: subagent.name,
+            description: this.getSubagentDescription(subagent),
+            tokens,
+          })
+          totalTokens += tokens
+        }
+
+        return { subagents, totalTokens, descriptionTokens }
+      }
+
+      if (!taskTool?.description) {
         return { subagents, totalTokens, descriptionTokens }
       }
 
@@ -162,7 +242,6 @@ export class SkillAnalyzer {
 
       for (const subagent of parsedSubagents) {
         const tokens = await this.tokenizerManager.countTokens(subagent.rawText, tokenModel)
-
         subagents.push({
           name: subagent.name,
           description: subagent.description,
@@ -181,7 +260,7 @@ export class SkillAnalyzer {
   }
 
   /**
-   * Parse the subagent list from task tool description
+   * Parse available subagents from the task tool description.
    */
   private parseAvailableSubagents(
     description: string
@@ -234,7 +313,7 @@ export class SkillAnalyzer {
         continue
       }
 
-      if (!this.isLikelySubagentName(name)) {
+      if (!this.isLikelyIdentifier(name)) {
         continue
       }
 
@@ -249,7 +328,102 @@ export class SkillAnalyzer {
     return subagents
   }
 
-  private isLikelySubagentName(name: string): boolean {
+  /**
+   * Parse the available skills list from both current markdown and legacy XML formats.
+   */
+  private parseAvailableSkills(description: string): ParsedSkillEntry[] {
+    const xmlSkills = this.parseAvailableSkillsXml(description)
+    if (xmlSkills.length > 0) {
+      return xmlSkills
+    }
+
+    return this.parseAvailableSkillsMarkdown(description)
+  }
+
+  private parseAvailableSkillsXml(description: string): ParsedSkillEntry[] {
+    const skills: ParsedSkillEntry[] = []
+    const availableSkillsMatch = description.match(/<available_skills>([\s\S]*?)<\/available_skills>/i)
+    if (!availableSkillsMatch) {
+      return skills
+    }
+
+    const xmlContent = availableSkillsMatch[1]
+    const skillBlockRegex = /<skill>([\s\S]*?)<\/skill>/gi
+    let blockMatch: RegExpExecArray | null
+
+    while ((blockMatch = skillBlockRegex.exec(xmlContent)) !== null) {
+      const block = blockMatch[0]
+      const body = blockMatch[1]
+      const nameMatch = body.match(/<name>([\s\S]*?)<\/name>/i)
+      const descriptionMatch = body.match(/<description>([\s\S]*?)<\/description>/i)
+
+      const name = nameMatch?.[1]?.trim() ?? ""
+      const skillDescription = descriptionMatch?.[1]?.trim() ?? ""
+      if (!name || !skillDescription) {
+        continue
+      }
+
+      skills.push({
+        name,
+        description: skillDescription,
+        rawText: block,
+      })
+    }
+
+    return skills
+  }
+
+  private parseAvailableSkillsMarkdown(description: string): ParsedSkillEntry[] {
+    const skills: ParsedSkillEntry[] = []
+    const lines = description.split(/\r?\n/)
+    const startIndex = lines.findIndex((line) => /^##\s+available skills\s*$/i.test(line.trim()))
+
+    if (startIndex === -1) {
+      return skills
+    }
+
+    let parsedAnyEntries = false
+
+    for (let i = startIndex + 1; i < lines.length; i++) {
+      const trimmed = lines[i].trim()
+
+      if (!trimmed) {
+        if (parsedAnyEntries) {
+          break
+        }
+        continue
+      }
+
+      if (/^#{1,6}\s/.test(trimmed)) {
+        break
+      }
+
+      const match = trimmed.match(/^-\s+\*\*([^*]+)\*\*:\s*(.+)$/) ?? trimmed.match(/^-\s+([^:]+):\s*(.+)$/)
+      if (!match) {
+        if (parsedAnyEntries) {
+          break
+        }
+        continue
+      }
+
+      const name = match[1]?.trim() ?? ""
+      const skillDescription = match[2]?.trim() ?? ""
+      if (!name || !skillDescription || !this.isLikelyIdentifier(name)) {
+        continue
+      }
+
+      skills.push({
+        name,
+        description: skillDescription.replace(/\s+/g, " ").trim(),
+        rawText: trimmed,
+      })
+      parsedAnyEntries = true
+    }
+
+    return skills
+  }
+
+  private isLikelyIdentifier(name: string): boolean {
     return /^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$/.test(name)
   }
 
@@ -269,54 +443,12 @@ export class SkillAnalyzer {
   }
 
   /**
-   * Parse the <available_skills> XML from skill tool description
-   */
-  private parseAvailableSkillsXml(description: string): Array<{ name: string; description: string }> {
-    const skills: Array<{ name: string; description: string }> = []
-
-    // Find the <available_skills> section
-    const availableSkillsMatch = description.match(/<available_skills>([\s\S]*?)<\/available_skills>/i)
-    if (!availableSkillsMatch) {
-      return skills
-    }
-
-    const xmlContent = availableSkillsMatch[1]
-
-    // Parse each <skill> block first, then extract known tags.
-    // This keeps parsing resilient when upstream adds nested tags
-    // (for example, <location> in anomalyco/opencode).
-    const skillBlockRegex = /<skill>([\s\S]*?)<\/skill>/gi
-    let blockMatch
-
-    while ((blockMatch = skillBlockRegex.exec(xmlContent)) !== null) {
-      const block = blockMatch[1]
-      const nameMatch = block.match(/<name>([\s\S]*?)<\/name>/i)
-      const descriptionMatch = block.match(/<description>([\s\S]*?)<\/description>/i)
-
-      const name = nameMatch?.[1]?.trim() ?? ""
-      const description = descriptionMatch?.[1]?.trim() ?? ""
-
-      if (!name || !description) {
-        continue
-      }
-
-      skills.push({
-        name,
-        description,
-      })
-    }
-
-    return skills
-  }
-
-  /**
-   * Collect loaded skills from session messages with call count tracking
+   * Collect loaded skills from session messages with call count tracking.
    */
   private async getLoadedSkills(
     messages: SessionMessage[],
     tokenModel: TokenModel
   ): Promise<{ skills: LoadedSkill[]; totalTokens: number }> {
-    // Track skills by name to aggregate call counts
     const skillMap = new Map<
       string,
       {
@@ -331,7 +463,6 @@ export class SkillAnalyzer {
     let messageIndex = 0
 
     for (const message of messages) {
-      // Track message index for user/assistant messages
       if (message.info.role === "user" || message.info.role === "assistant") {
         messageIndex++
       }
@@ -341,21 +472,16 @@ export class SkillAnalyzer {
         if (part.tool !== "skill") continue
         if (part.state.status !== "completed") continue
 
-        // Extract skill name from input or metadata
         const skillName = this.extractSkillName(part.state)
         if (!skillName) continue
 
-        // Get the output content
         const content = (part.state.output ?? "").toString().trim()
         if (!content) continue
 
-        // Check if we've seen this skill before
         const existing = skillMap.get(skillName)
         if (existing) {
-          // Increment call count for existing skill
           existing.callCount++
         } else {
-          // Tokenize the loaded content (only once per unique skill)
           const tokens = await this.tokenizerManager.countTokens(content, tokenModel)
 
           skillMap.set(skillName, {
@@ -369,12 +495,6 @@ export class SkillAnalyzer {
       }
     }
 
-    // Convert map to array and calculate totals
-    // Note: We multiply tokens by callCount because OpenCode does NOT deduplicate
-    // skill content. Each call to the skill tool adds the full content to context
-    // as a new tool result. See OpenCode source:
-    // - Skill tool execution: https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/tool/skill.ts
-    // - Tool result handling: https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/message-v2.ts
     const skills: LoadedSkill[] = []
     for (const [, skillData] of skillMap) {
       const totalSkillTokens = skillData.tokens * skillData.callCount
@@ -389,27 +509,23 @@ export class SkillAnalyzer {
       totalTokens += totalSkillTokens
     }
 
-    // Sort by total tokens descending
     skills.sort((a, b) => b.totalTokens - a.totalTokens)
 
     return { skills, totalTokens }
   }
 
   /**
-   * Extract skill name from tool state
+   * Extract skill name from tool state.
    */
   private extractSkillName(state: any): string | undefined {
-    // Try input.name first
     if (state.input && typeof state.input === "object" && state.input.name) {
       return String(state.input.name)
     }
 
-    // Try metadata.name
     if (state.metadata && typeof state.metadata === "object" && state.metadata.name) {
       return String(state.metadata.name)
     }
 
-    // Try parsing from title "Loaded skill: {name}"
     if (state.title && typeof state.title === "string") {
       const match = state.title.match(/Loaded skill:\s*(.+)/i)
       if (match) {
@@ -418,5 +534,232 @@ export class SkillAnalyzer {
     }
 
     return undefined
+  }
+
+  private resolveCurrentAgent(messages: SessionMessage[], agents?: RemoteAgent[]): RemoteAgent | undefined {
+    if (!agents || agents.length === 0) {
+      return undefined
+    }
+
+    const agentName = [...messages]
+      .reverse()
+      .map((message) => message.info.agent)
+      .find((value) => typeof value === "string" && value.trim().length > 0)
+
+    if (!agentName) {
+      return undefined
+    }
+
+    return agents.find((agent) => agent.name === agentName)
+  }
+
+  private filterAccessibleSkills(skills?: RemoteSkill[], currentAgent?: RemoteAgent): RemoteSkill[] | undefined {
+    if (!skills) {
+      return undefined
+    }
+
+    const rules = this.getPermissionRules(currentAgent?.permission)
+    const filtered = rules
+      ? skills.filter((skill) => this.evaluatePermission("skill", skill.name, rules).action !== "deny")
+      : skills
+
+    return [...filtered].sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  private filterAccessibleSubagents(agents?: RemoteAgent[], currentAgent?: RemoteAgent): RemoteAgent[] | undefined {
+    if (!agents) {
+      return undefined
+    }
+
+    const rules = this.getPermissionRules(currentAgent?.permission)
+    const subagents = agents.filter((agent) => agent.mode !== "primary")
+    const filtered = rules
+      ? subagents.filter((agent) => this.evaluatePermission("task", agent.name, rules).action !== "deny")
+      : subagents
+
+    return [...filtered].sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  private getPermissionRules(value: unknown): PermissionRule[] | undefined {
+    if (!Array.isArray(value)) {
+      return undefined
+    }
+
+    const rules = value.filter(
+      (item): item is PermissionRule =>
+        !!item &&
+        typeof item === "object" &&
+        typeof (item as any).permission === "string" &&
+        typeof (item as any).pattern === "string" &&
+        typeof (item as any).action === "string"
+    )
+
+    return rules.length > 0 ? rules : undefined
+  }
+
+  private evaluatePermission(permission: string, pattern: string, ruleset: PermissionRule[]): PermissionRule {
+    const match = [...ruleset]
+      .reverse()
+      .find(
+        (rule) => this.matchesWildcard(permission, rule.permission) && this.matchesWildcard(pattern, rule.pattern)
+      )
+
+    return match ?? { permission, pattern: "*", action: "ask" }
+  }
+
+  private matchesWildcard(value: string, pattern: string): boolean {
+    const normalizedValue = value.replaceAll("\\", "/")
+    const normalizedPattern = pattern.replaceAll("\\", "/")
+
+    let escaped = normalizedPattern
+      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+      .replace(/\*/g, ".*")
+      .replace(/\?/g, ".")
+
+    if (escaped.endsWith(" .*")) {
+      escaped = escaped.slice(0, -3) + "( .*)?"
+    }
+
+    const flags = process.platform === "win32" ? "si" : "s"
+    return new RegExp("^" + escaped + "$", flags).test(normalizedValue)
+  }
+
+  private buildVerboseSkillEntry(skill: RemoteSkill): string {
+    const lines = [
+      "  <skill>",
+      `    <name>${skill.name}</name>`,
+      `    <description>${skill.description}</description>`,
+    ]
+
+    if (skill.location) {
+      lines.push(`    <location>${pathToFileURL(skill.location).href}</location>`)
+    }
+
+    lines.push("  </skill>")
+    return lines.join("\n")
+  }
+
+  private buildSkillSystemPrompt(skills: RemoteSkill[]): string {
+    return [
+      "Skills provide specialized instructions and workflows for specific tasks.",
+      "Use the skill tool to load a skill when a task matches its description.",
+      skills.length > 0 ? this.buildVerboseSkillCatalog(skills) : "No skills are currently available.",
+    ].join("\n")
+  }
+
+  private buildVerboseSkillCatalog(skills: RemoteSkill[]): string {
+    return ["<available_skills>", ...skills.map((skill) => this.buildVerboseSkillEntry(skill)), "</available_skills>"].join(
+      "\n"
+    )
+  }
+
+  private buildSkillToolDescription(skills: RemoteSkill[]): string {
+    if (skills.length === 0) {
+      return "Load a specialized skill that provides domain-specific instructions and workflows. No skills are currently available."
+    }
+
+    return [
+      "Load a specialized skill that provides domain-specific instructions and workflows.",
+      "",
+      "When you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.",
+      "",
+      "The skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.",
+      "",
+      'Tool output includes a `<skill_content name="...">` block with the loaded content.',
+      "",
+      "The following skills provide specialized sets of instructions for particular tasks",
+      "Invoke this tool to load a skill when a task matches one of the available skills listed below:",
+      "",
+      [
+        "## Available Skills",
+        ...skills.map((skill) => `- **${skill.name}**: ${skill.description}`),
+      ].join("\n"),
+    ].join("\n")
+  }
+
+  private buildSubagentBullet(agent: RemoteAgent): string {
+    return `- ${agent.name}: ${this.getSubagentDescription(agent)}`
+  }
+
+  private getSubagentDescription(agent: RemoteAgent): string {
+    return agent.description ?? "This subagent should only be called manually by the user."
+  }
+
+  private buildFilteredTaskDescription(description: string, agents: RemoteAgent[]): string {
+    const lines = description.split(/\r?\n/)
+    const headerIndex = lines.findIndex((line) => /available agent types/i.test(line))
+    const nextSectionIndex = lines.findIndex((line, index) => index > headerIndex && /^When using the Task tool:/i.test(line.trim()))
+
+    if (headerIndex === -1 || nextSectionIndex === -1) {
+      return description
+    }
+
+    return [
+      ...lines.slice(0, headerIndex + 1),
+      ...agents.map((agent) => this.buildSubagentBullet(agent)),
+      "",
+      ...lines.slice(nextSectionIndex),
+    ].join("\n")
+  }
+
+  private async fetchAgents(): Promise<RemoteAgent[] | undefined> {
+    try {
+      const agents = await this.fetchInternalJson<RemoteAgent[]>("agent")
+      if (Array.isArray(agents)) {
+        return agents
+      }
+    } catch {}
+
+    try {
+      const appAgents = (this.client as any)?.app?.agents
+      if (typeof appAgents === "function") {
+        const response = await appAgents.call((this.client as any).app)
+        const agents = (response as any)?.data ?? response
+        if (Array.isArray(agents)) {
+          return agents as RemoteAgent[]
+        }
+      }
+    } catch {}
+
+    return undefined
+  }
+
+  private async fetchSkills(): Promise<RemoteSkill[] | undefined> {
+    try {
+      const skills = await this.fetchInternalJson<RemoteSkill[]>("skill")
+      if (Array.isArray(skills)) {
+        return skills
+      }
+    } catch {}
+
+    try {
+      const appSkills = (this.client as any)?.app?.skills
+      if (typeof appSkills === "function") {
+        const response = await appSkills.call((this.client as any).app)
+        const skills = (response as any)?.data ?? response
+        if (Array.isArray(skills)) {
+          return skills as RemoteSkill[]
+        }
+      }
+    } catch {}
+
+    return undefined
+  }
+
+  private async fetchInternalJson<T>(pathname: string): Promise<T> {
+    const base = new URL(this.serverUrl)
+    if (!base.pathname.endsWith("/")) {
+      base.pathname += "/"
+    }
+
+    const url = new URL(pathname.replace(/^\//, ""), base)
+    url.searchParams.set("directory", this.directory)
+
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Request failed (${response.status} ${response.statusText})`)
+    }
+
+    return (await response.json()) as T
   }
 }

--- a/plugin/tokenscope-lib/subagent.ts
+++ b/plugin/tokenscope-lib/subagent.ts
@@ -2,6 +2,7 @@
 
 import type { SessionMessage, SubagentSummary, SubagentAnalysis, ChildSession } from "./types"
 import { CostCalculator } from "./cost"
+import { fetchSessionChildren, fetchSessionMessages, unwrapResponseData } from "./opencode"
 import { WarningCollector, formatErrorMessage } from "./warnings"
 
 export class SubagentAnalyzer {
@@ -26,8 +27,8 @@ export class SubagentAnalyzer {
     }
 
     try {
-      const childrenResponse = await this.client.session.children({ path: { id: parentSessionID } })
-      const children: ChildSession[] = ((childrenResponse as any)?.data ?? childrenResponse ?? []) as ChildSession[]
+      const childrenResponse = await fetchSessionChildren(this.client, parentSessionID)
+      const children: ChildSession[] = unwrapResponseData<ChildSession[]>(childrenResponse ?? [])
 
       if (!Array.isArray(children) || children.length === 0) return result
 
@@ -72,8 +73,8 @@ export class SubagentAnalyzer {
 
   private async analyzeChildSession(child: ChildSession): Promise<SubagentSummary | null> {
     try {
-      const messagesResponse = await this.client.session.messages({ path: { id: child.id } })
-      const messages: SessionMessage[] = ((messagesResponse as any)?.data ?? messagesResponse ?? []) as SessionMessage[]
+      const messagesResponse = await fetchSessionMessages(this.client, child.id)
+      const messages: SessionMessage[] = unwrapResponseData<SessionMessage[]>(messagesResponse ?? [])
 
       if (!Array.isArray(messages) || messages.length === 0) return null
 
@@ -154,7 +155,7 @@ export class SubagentAnalyzer {
   }
 
   private extractAgentType(title: string): string {
-    const match = title.match(/@(\w+)\s+subagent/i)
+    const match = title.match(/@([A-Za-z0-9._-]+)\s+subagent/i)
     if (match) return match[1]
     const words = title.split(/\s+/)
     return words[0]?.toLowerCase() || "subagent"

--- a/plugin/tokenscope-lib/types.ts
+++ b/plugin/tokenscope-lib/types.ts
@@ -8,6 +8,11 @@ export interface SessionMessage {
 export interface SessionMessageInfo {
   id: string
   role: string
+  agent?: string
+  model?: {
+    providerID?: string
+    modelID?: string
+  }
   modelID?: string
   providerID?: string
   system?: string | string[]
@@ -254,6 +259,11 @@ export interface ExportedMessage {
 export interface ExportedMessageInfo {
   id: string
   role: "user" | "assistant"
+  agent?: string
+  model?: {
+    providerID?: string
+    modelID?: string
+  }
   system?: string | string[]
   tools?: Record<string, boolean>
   tokens?: TokenUsage

--- a/plugin/tokenscope-lib/types.ts
+++ b/plugin/tokenscope-lib/types.ts
@@ -218,6 +218,7 @@ export interface SkillAnalysis {
   totalAvailableTokens: number
   totalAvailableSubagentTokens: number
   totalLoadedTokens: number
+  availableSkillsContextTokens: number
   skillToolDescriptionTokens: number
   taskToolDescriptionTokens: number
 }

--- a/plugin/tokenscope.ts
+++ b/plugin/tokenscope.ts
@@ -60,7 +60,7 @@ function buildFailureReport(sessionID: string | undefined, warnings: string[], f
   return lines.join("\n")
 }
 
-export const TokenAnalyzerPlugin: Plugin = async ({ client }) => {
+export const TokenAnalyzerPlugin: Plugin = async ({ client, serverUrl, directory }) => {
   const pricingData = await loadModelPricing()
   const config = await loadTokenscopeConfig()
 
@@ -89,7 +89,7 @@ export const TokenAnalyzerPlugin: Plugin = async ({ client }) => {
           const analysisEngine = new TokenAnalysisEngine(tokenizerManager, contentCollector)
           const subagentAnalyzer = new SubagentAnalyzer(client, costCalculator, warnings)
           const contextAnalyzer = new ContextAnalyzer(tokenizerManager, warnings)
-          const skillAnalyzer = new SkillAnalyzer(client, tokenizerManager, warnings)
+          const skillAnalyzer = new SkillAnalyzer(client, tokenizerManager, serverUrl, directory, warnings)
           const formatter = new OutputFormatter(costCalculator)
           formatter.setConfig(config)
 

--- a/plugin/tokenscope.ts
+++ b/plugin/tokenscope.ts
@@ -14,6 +14,7 @@ import { SubagentAnalyzer } from "./tokenscope-lib/subagent"
 import { OutputFormatter } from "./tokenscope-lib/formatter"
 import { ContextAnalyzer } from "./tokenscope-lib/context"
 import { SkillAnalyzer } from "./tokenscope-lib/skill"
+import { fetchSessionMessages, unwrapResponseData } from "./tokenscope-lib/opencode"
 import { WarningCollector, formatErrorMessage } from "./tokenscope-lib/warnings"
 
 const REPORT_FILENAME = "token-usage-output.txt"
@@ -103,8 +104,8 @@ export const TokenAnalyzerPlugin: Plugin = async ({ client }) => {
           }
 
           try {
-            const response = await client.session.messages({ path: { id: sessionID } })
-            const messages: SessionMessage[] = ((response as any)?.data ?? response ?? []) as SessionMessage[]
+            const response = await fetchSessionMessages(client, sessionID)
+            const messages: SessionMessage[] = unwrapResponseData<SessionMessage[]>(response ?? [])
 
             if (!Array.isArray(messages) || messages.length === 0) {
               const output = buildFailureReport(sessionID, warnings.list(), `Session ${sessionID} has no messages yet.`)


### PR DESCRIPTION
## Summary
Audit TokenScope against the current `anomalyco/opencode` core and bring the plugin back in line with the SDK/session shapes and prompt layout that changed since the last npm release.

Current upstream audit target: `anomalyco/opencode@00fa68b3a`

## What changed
- support newer OpenCode session payloads and SDK route shapes
- resolve model/provider from nested user-message model metadata
- keep subagent analysis compatible with newer child-session/message accessors
- refresh skill/subagent accounting using the current OpenCode agent + skill catalogs
- account for the verbose skill catalog now injected via the system prompt
- keep fallback parsing for older skill/task tool description formats
- update report wording and README notes to match current OpenCode behavior

## Commit breakdown
1. `fix(opencode): support newer session payloads`
2. `fix(skills): align catalog accounting with current opencode`
3. `docs(readme): refresh skill accounting notes`

## Validation
- `cd plugin && npm run typecheck`
- `cd plugin && npm run build`
