### PR TITLE
add deepseek v4-flash and v4-pro pricing

### DIFF
--- a/plugin/models.json
+++ b/plugin/models.json
@@ -6953,6 +6953,18 @@
     "cacheWrite": 0,
     "cacheRead": 0.028
   },
+  "deepseek/deepseek-v4-flash": {
+    "input": 0.14,
+    "output": 0.28,
+    "cacheWrite": 0,
+    "cacheRead": 0.0028
+  },
+  "deepseek/deepseek-v4-pro": {
+    "input": 0.435,
+    "output": 0.87,
+    "cacheWrite": 0,
+    "cacheRead": 0.003625
+  },
   "devstral-2-123b-instruct-2512-tee": {
     "input": 0.05,
     "output": 0.22,


### PR DESCRIPTION
Add pricing entries for deepseek-v4-flash and deepseek-v4-pro from https://api-docs.deepseek.com/quick_start/pricing

Closes #28

| Model | Input (miss) | Input (hit) | Output |
|---|---|---|---|
| deepseek-v4-flash | \.14/M | \.0028/M | \.28/M |
| deepseek-v4-pro | \.435/M | \.003625/M | \.87/M |

Note: v4-pro pricing reflects the current 75% discount (valid until 2026/05/31).