### PR TITLE
fix(plugin): use explicit ESM import specifiers

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "npm run clean && tsc",
-    "test": "bun test",
+    "test": "bun test && npm run test:dist",
+    "test:dist": "npm run build && node -e \"await import('./dist/tokenscope.js')\"",
     "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit"
   },

--- a/plugin/tokenscope-lib/analyzer.ts
+++ b/plugin/tokenscope-lib/analyzer.ts
@@ -11,11 +11,11 @@ import type {
   isToolPart,
   isReasoningPart,
   isTextPart,
-} from "./types"
-import { isToolPart as toolGuard, isReasoningPart as reasoningGuard, isTextPart as textGuard } from "./types"
-import { OPENAI_MODEL_MAP, HUGGINGFACE_TOKENIZER_MODEL_MAP, PROVIDER_DEFAULTS } from "./config"
-import { TokenizerManager } from "./tokenizer"
-import { summarizeTelemetry } from "./telemetry"
+} from "./types.js"
+import { isToolPart as toolGuard, isReasoningPart as reasoningGuard, isTextPart as textGuard } from "./types.js"
+import { OPENAI_MODEL_MAP, HUGGINGFACE_TOKENIZER_MODEL_MAP, PROVIDER_DEFAULTS } from "./config.js"
+import { TokenizerManager } from "./tokenizer.js"
+import { summarizeTelemetry } from "./telemetry.js"
 
 // Model Resolution
 

--- a/plugin/tokenscope-lib/config.ts
+++ b/plugin/tokenscope-lib/config.ts
@@ -4,7 +4,7 @@ import path from "path"
 import fs from "fs/promises"
 import { homedir } from "os"
 import { fileURLToPath } from "url"
-import type { TokenizerSpec, ModelPricing, TokenscopeConfig } from "./types"
+import type { TokenizerSpec, ModelPricing, TokenscopeConfig } from "./types.js"
 
 export const DEFAULT_ENTRY_LIMIT = 3
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url))

--- a/plugin/tokenscope-lib/context.ts
+++ b/plugin/tokenscope-lib/context.ts
@@ -12,10 +12,10 @@ import type {
   ModelPricing,
   TokenModel,
   ContextAnalysisResult,
-} from "./types"
-import { TokenizerManager } from "./tokenizer"
-import { firstCacheWriteTokens, summarizeTelemetry } from "./telemetry"
-import { WarningCollector, formatErrorMessage } from "./warnings"
+} from "./types.js"
+import { TokenizerManager } from "./tokenizer.js"
+import { firstCacheWriteTokens, summarizeTelemetry } from "./telemetry.js"
+import { WarningCollector, formatErrorMessage } from "./warnings.js"
 
 export class ContextAnalyzer {
   private tokenizerManager: TokenizerManager

--- a/plugin/tokenscope-lib/cost.ts
+++ b/plugin/tokenscope-lib/cost.ts
@@ -1,6 +1,6 @@
 // CostCalculator - calculates costs from token analysis
 
-import type { TokenAnalysis, CostEstimate, ModelPricing } from "./types"
+import type { TokenAnalysis, CostEstimate, ModelPricing } from "./types.js"
 
 export class CostCalculator {
   constructor(private pricingData: Record<string, ModelPricing>) {}

--- a/plugin/tokenscope-lib/formatter.ts
+++ b/plugin/tokenscope-lib/formatter.ts
@@ -10,8 +10,8 @@ import type {
   CacheEfficiency,
   TokenscopeConfig,
   SkillAnalysis,
-} from "./types"
-import { CostCalculator } from "./cost"
+} from "./types.js"
+import { CostCalculator } from "./cost.js"
 
 export class OutputFormatter {
   private readonly BAR_WIDTH = 30

--- a/plugin/tokenscope-lib/skill.ts
+++ b/plugin/tokenscope-lib/skill.ts
@@ -10,10 +10,10 @@ import type {
   LoadedSkill,
   TokenModel,
   TokenscopeConfig,
-} from "./types"
-import { isToolPart } from "./types"
-import { TokenizerManager } from "./tokenizer"
-import { WarningCollector, formatErrorMessage } from "./warnings"
+} from "./types.js"
+import { isToolPart } from "./types.js"
+import { TokenizerManager } from "./tokenizer.js"
+import { WarningCollector, formatErrorMessage } from "./warnings.js"
 
 interface ToolListItem {
   id: string

--- a/plugin/tokenscope-lib/subagent.ts
+++ b/plugin/tokenscope-lib/subagent.ts
@@ -1,10 +1,10 @@
 // SubagentAnalyzer - analyzes child sessions from Task tool calls
 
-import type { SessionMessage, SubagentSummary, SubagentAnalysis, ChildSession } from "./types"
-import { CostCalculator } from "./cost"
-import { fetchSessionChildren, fetchSessionMessages, unwrapResponseData } from "./opencode"
-import { summarizeTelemetry } from "./telemetry"
-import { WarningCollector, formatErrorMessage } from "./warnings"
+import type { SessionMessage, SubagentSummary, SubagentAnalysis, ChildSession } from "./types.js"
+import { CostCalculator } from "./cost.js"
+import { fetchSessionChildren, fetchSessionMessages, unwrapResponseData } from "./opencode.js"
+import { summarizeTelemetry } from "./telemetry.js"
+import { WarningCollector, formatErrorMessage } from "./warnings.js"
 
 export class SubagentAnalyzer {
   constructor(

--- a/plugin/tokenscope-lib/telemetry.ts
+++ b/plugin/tokenscope-lib/telemetry.ts
@@ -1,6 +1,6 @@
 // Telemetry helpers - extracts per-API-call token and cost data from stored session messages
 
-import type { TokenUsage } from "./types"
+import type { TokenUsage } from "./types.js"
 
 export interface TelemetryCall {
   inputTokens: number

--- a/plugin/tokenscope-lib/tokenizer.ts
+++ b/plugin/tokenscope-lib/tokenizer.ts
@@ -1,7 +1,7 @@
 // TokenizerManager - handles token counting with multiple backends
 
-import type { TokenModel } from "./types"
-import { WarningCollector, formatErrorMessage } from "./warnings"
+import type { TokenModel } from "./types.js"
+import { WarningCollector, formatErrorMessage } from "./warnings.js"
 
 const APPROXIMATE_ONLY_HUGGINGFACE_HUBS = new Set(["google/gemma-2-9b-it"])
 

--- a/plugin/tokenscope.ts
+++ b/plugin/tokenscope.ts
@@ -1,21 +1,21 @@
 // OpenCode Token Analyzer Plugin - Main Entry Point
 
 import type { Plugin } from "@opencode-ai/plugin"
-import { tool } from "@opencode-ai/plugin"
+import { tool } from "@opencode-ai/plugin/tool"
 import path from "path"
 import fs from "fs/promises"
 
-import type { SessionMessage } from "./tokenscope-lib/types"
-import { DEFAULT_ENTRY_LIMIT, loadModelPricing, loadTokenscopeConfig } from "./tokenscope-lib/config"
-import { TokenizerManager } from "./tokenscope-lib/tokenizer"
-import { ModelResolver, ContentCollector, TokenAnalysisEngine } from "./tokenscope-lib/analyzer"
-import { CostCalculator } from "./tokenscope-lib/cost"
-import { SubagentAnalyzer } from "./tokenscope-lib/subagent"
-import { OutputFormatter } from "./tokenscope-lib/formatter"
-import { ContextAnalyzer } from "./tokenscope-lib/context"
-import { SkillAnalyzer } from "./tokenscope-lib/skill"
-import { fetchSessionMessages, unwrapResponseData } from "./tokenscope-lib/opencode"
-import { WarningCollector, formatErrorMessage } from "./tokenscope-lib/warnings"
+import type { SessionMessage } from "./tokenscope-lib/types.js"
+import { DEFAULT_ENTRY_LIMIT, loadModelPricing, loadTokenscopeConfig } from "./tokenscope-lib/config.js"
+import { TokenizerManager } from "./tokenscope-lib/tokenizer.js"
+import { ModelResolver, ContentCollector, TokenAnalysisEngine } from "./tokenscope-lib/analyzer.js"
+import { CostCalculator } from "./tokenscope-lib/cost.js"
+import { SubagentAnalyzer } from "./tokenscope-lib/subagent.js"
+import { OutputFormatter } from "./tokenscope-lib/formatter.js"
+import { ContextAnalyzer } from "./tokenscope-lib/context.js"
+import { SkillAnalyzer } from "./tokenscope-lib/skill.js"
+import { fetchSessionMessages, unwrapResponseData } from "./tokenscope-lib/opencode.js"
+import { WarningCollector, formatErrorMessage } from "./tokenscope-lib/warnings.js"
 
 const REPORT_FILENAME = "token-usage-output.txt"
 


### PR DESCRIPTION
## Summary
- add `.js` extensions to relative ESM imports so the compiled plugin loads in strict ESM environments
- import `tool` from the explicit `@opencode-ai/plugin/tool` subpath

## Validation
- npm run typecheck
- npm test
- npm run build
- node -e "import('./dist/tokenscope.js').then(m => console.log(Object.keys(m).join(',')))"

Closes #30