### PR TITLE
chore(release): prepare 1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.4] - 2026-05-20
+
+### Added
+
+- Added DeepSeek V4 Flash and DeepSeek V4 Pro pricing entries
+- Added a compiled `dist/` ESM smoke test to catch strict loader regressions
+
+### Fixed
+
+- Added explicit `.js` extensions to compiled ESM imports so TokenScope loads in strict ESM environments such as OpenCode Desktop (#30)
+
 ## [1.6.3] - 2026-04-14
 
 ### Added
@@ -93,7 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synced READMEs and removed version tags from feature headers
 - Updated install script for better testing before npm push
 
-[Unreleased]: https://github.com/ramtinJ95/opencode-tokenscope/compare/v1.6.3...HEAD
+[Unreleased]: https://github.com/ramtinJ95/opencode-tokenscope/compare/v1.6.4...HEAD
+[1.6.4]: https://github.com/ramtinJ95/opencode-tokenscope/compare/v1.6.3...v1.6.4
 [1.6.3]: https://github.com/ramtinJ95/opencode-tokenscope/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/ramtinJ95/opencode-tokenscope/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/ramtinJ95/opencode-tokenscope/compare/v1.6.0...v1.6.1

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Then restart OpenCode and run `/tokenscope`
 |---------------------------|----------|
 | `"@ramtinj95/opencode-tokenscope"` | Uses the version installed at install time. **Never auto-updates.** |
 | `"@ramtinj95/opencode-tokenscope@latest"` | Fetches latest version **every time OpenCode starts**. |
-| `"@ramtinj95/opencode-tokenscope@1.6.3"` | Pins to exact version 1.6.3. Never updates. |
+| `"@ramtinj95/opencode-tokenscope@1.6.4"` | Pins to exact version 1.6.4. Never updates. |
 
 To manually update:
 ```bash

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -63,7 +63,7 @@ Then restart OpenCode and run `/tokenscope`
 |---------------------------|----------|
 | `"@ramtinj95/opencode-tokenscope"` | Uses the version installed at install time. **Never auto-updates.** |
 | `"@ramtinj95/opencode-tokenscope@latest"` | Fetches latest version **every time OpenCode starts**. |
-| `"@ramtinj95/opencode-tokenscope@1.6.3"` | Pins to exact version 1.6.3. Never updates. |
+| `"@ramtinj95/opencode-tokenscope@1.6.4"` | Pins to exact version 1.6.4. Never updates. |
 
 To manually update:
 ```bash

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@ramtinj95/opencode-tokenscope",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "OpenCode plugin for detailed token usage analysis with breakdowns by category, visual charts, and subagent cost tracking",
   "type": "module",
   "main": "./dist/tokenscope.js",


### PR DESCRIPTION
## Summary
- bump package version and pinned README examples to 1.6.4
- add 1.6.4 changelog entries for DeepSeek pricing and strict ESM loader fixes

## Validation
- npm run typecheck
- npm test
- npm pack --dry-run