### PR TITLE
Fix per-model cost attribution

### DIFF
--- a/plugin/test/cost.test.ts
+++ b/plugin/test/cost.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "bun:test"
+
+import { CostCalculator } from "../tokenscope-lib/cost.js"
+import { summarizeTelemetry } from "../tokenscope-lib/telemetry.js"
+import type { TokenAnalysis } from "../tokenscope-lib/types.js"
+
+function emptyCategory(label: string) {
+  return { label, totalTokens: 0, entries: [], allEntries: [] }
+}
+
+function baseAnalysis(overrides: Partial<TokenAnalysis>): TokenAnalysis {
+  return {
+    sessionID: "ses_test",
+    model: { name: "claude-sonnet-4-20250514", spec: { kind: "approx" } },
+    categories: {
+      system: emptyCategory("system"),
+      user: emptyCategory("user"),
+      assistant: emptyCategory("assistant"),
+      tools: emptyCategory("tools"),
+      reasoning: emptyCategory("reasoning"),
+    },
+    totalTokens: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    assistantMessageCount: 0,
+    apiCallCount: 0,
+    callsWithCacheRead: 0,
+    callsWithCacheWrite: 0,
+    mostRecentInput: 0,
+    mostRecentOutput: 0,
+    mostRecentReasoning: 0,
+    mostRecentCacheRead: 0,
+    mostRecentCacheWrite: 0,
+    sessionCost: 0,
+    mostRecentCost: 0,
+    allToolsCalled: [],
+    toolCallCounts: new Map(),
+    perModelUsage: [],
+    warnings: [],
+    ...overrides,
+  }
+}
+
+test("summarizeTelemetry keeps cache buckets split by assistant message model", () => {
+  const telemetry = summarizeTelemetry([
+    {
+      info: { role: "assistant" },
+      data: { model: { providerID: "anthropic", modelID: "claude-sonnet-4-20250514" } },
+      parts: [
+        {
+          type: "step-finish",
+          tokens: { input: 1_000, output: 200, reasoning: 0, cache: { read: 100_000, write: 1_000 } },
+          cost: 0,
+        },
+      ],
+    },
+    {
+      info: { role: "assistant" },
+      data: { model: { providerID: "google", modelID: "gemini-2.5-flash" } },
+      parts: [
+        {
+          type: "step-finish",
+          tokens: { input: 2_000, output: 400, reasoning: 50, cache: { read: 50_000, write: 0 } },
+          cost: 0,
+        },
+      ],
+    },
+  ])
+
+  expect(telemetry.cacheReadTokens).toBe(150_000)
+  expect(telemetry.perModelUsage).toHaveLength(2)
+  expect(telemetry.perModelUsage.find((model) => model.modelID === "claude-sonnet-4-20250514")?.cacheReadTokens).toBe(100_000)
+  expect(telemetry.perModelUsage.find((model) => model.modelID === "gemini-2.5-flash")?.cacheReadTokens).toBe(50_000)
+})
+
+test("calculateCost applies per-model prices to input output and cache token types", () => {
+  const calculator = new CostCalculator({
+    "anthropic/claude-sonnet-4-20250514": { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
+    "google/gemini-2.5-flash": { input: 0.3, output: 2.5, cacheWrite: 0, cacheRead: 0.075 },
+    default: { input: 1, output: 3, cacheWrite: 0, cacheRead: 0 },
+  })
+
+  const cost = calculator.calculateCost(
+    baseAnalysis({
+      inputTokens: 3_000,
+      outputTokens: 600,
+      reasoningTokens: 50,
+      cacheReadTokens: 150_000,
+      cacheWriteTokens: 1_000,
+      apiCallCount: 2,
+      perModelUsage: [
+        {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4-20250514",
+          modelName: "anthropic/claude-sonnet-4-20250514",
+          inputTokens: 1_000,
+          outputTokens: 200,
+          reasoningTokens: 0,
+          cacheReadTokens: 100_000,
+          cacheWriteTokens: 1_000,
+          apiCost: 0,
+          apiCallCount: 1,
+          callsWithCacheRead: 1,
+          callsWithCacheWrite: 1,
+        },
+        {
+          providerID: "google",
+          modelID: "gemini-2.5-flash",
+          modelName: "google/gemini-2.5-flash",
+          inputTokens: 2_000,
+          outputTokens: 400,
+          reasoningTokens: 50,
+          cacheReadTokens: 50_000,
+          cacheWriteTokens: 0,
+          apiCost: 0,
+          apiCallCount: 1,
+          callsWithCacheRead: 1,
+          callsWithCacheWrite: 0,
+        },
+      ],
+    })
+  )
+
+  expect(cost.perModelCosts).toHaveLength(2)
+  expect(cost.estimatedCacheReadCost).toBeCloseTo(0.03375)
+  expect(cost.estimatedSessionCost).toBeCloseTo(0.045225)
+  expect(cost.perModelCosts.find((model) => model.providerID === "anthropic")?.estimatedSessionCost).toBeCloseTo(0.03975)
+  expect(cost.perModelCosts.find((model) => model.providerID === "google")?.estimatedSessionCost).toBeCloseTo(0.005475)
+})
+

--- a/plugin/test/cost.test.ts
+++ b/plugin/test/cost.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 
+import { ModelResolver } from "../tokenscope-lib/analyzer.js"
 import { CostCalculator } from "../tokenscope-lib/cost.js"
 import { summarizeTelemetry } from "../tokenscope-lib/telemetry.js"
 import type { TokenAnalysis } from "../tokenscope-lib/types.js"
@@ -76,6 +77,36 @@ test("summarizeTelemetry keeps cache buckets split by assistant message model", 
   expect(telemetry.perModelUsage.find((model) => model.modelID === "gemini-2.5-flash")?.cacheReadTokens).toBe(50_000)
 })
 
+test("summarizeTelemetry reads top-level scalar provider and model IDs", () => {
+  const telemetry = summarizeTelemetry([
+    {
+      role: "assistant",
+      providerID: "openai",
+      modelID: "gpt-5.4-mini",
+      tokens: { input: 1_000, output: 100, reasoning: 0, cache: { read: 500, write: 0 } },
+      cost: 0,
+    },
+  ])
+
+  expect(telemetry.perModelUsage).toHaveLength(1)
+  expect(telemetry.perModelUsage[0]?.providerID).toBe("openai")
+  expect(telemetry.perModelUsage[0]?.modelID).toBe("gpt-5.4-mini")
+})
+
+test("ModelResolver reads scalar provider and model IDs from message data", () => {
+  const resolver = new ModelResolver()
+  const resolved = resolver.resolveModelAndProvider([
+    {
+      info: { id: "msg_1", role: "assistant" },
+      data: { providerID: "openai", modelID: "gpt-5.4-mini" },
+      parts: [],
+    },
+  ])
+
+  expect(resolved.providerID).toBe("openai")
+  expect(resolved.modelID).toBe("gpt-5.4-mini")
+})
+
 test("calculateCost applies per-model prices to input output and cache token types", () => {
   const calculator = new CostCalculator({
     "anthropic/claude-sonnet-4-20250514": { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
@@ -129,5 +160,38 @@ test("calculateCost applies per-model prices to input output and cache token typ
   expect(cost.estimatedSessionCost).toBeCloseTo(0.045225)
   expect(cost.perModelCosts.find((model) => model.providerID === "anthropic")?.estimatedSessionCost).toBeCloseTo(0.03975)
   expect(cost.perModelCosts.find((model) => model.providerID === "google")?.estimatedSessionCost).toBeCloseTo(0.005475)
+})
+
+test("calculateCost uses the analysis pricing model when telemetry model metadata is missing", () => {
+  const calculator = new CostCalculator({
+    "openai/gpt-5.4-mini": { input: 0.75, output: 4.5, cacheWrite: 0, cacheRead: 0.075 },
+    default: { input: 1, output: 3, cacheWrite: 0, cacheRead: 0 },
+  })
+
+  const cost = calculator.calculateCost(
+    baseAnalysis({
+      pricingModelName: "openai/gpt-5.4-mini",
+      inputTokens: 1_000,
+      outputTokens: 100,
+      apiCallCount: 1,
+      perModelUsage: [
+        {
+          modelName: "unknown model",
+          inputTokens: 1_000,
+          outputTokens: 100,
+          reasoningTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          apiCost: 0,
+          apiCallCount: 1,
+          callsWithCacheRead: 0,
+          callsWithCacheWrite: 0,
+        },
+      ],
+    })
+  )
+
+  expect(cost.perModelCosts[0]?.pricingModelName).toBe("openai/gpt-5.4-mini")
+  expect(cost.estimatedSessionCost).toBeCloseTo(0.0012)
 })
 

--- a/plugin/test/cost.test.ts
+++ b/plugin/test/cost.test.ts
@@ -93,6 +93,21 @@ test("summarizeTelemetry reads top-level scalar provider and model IDs", () => {
   expect(telemetry.perModelUsage[0]?.modelID).toBe("gpt-5.4-mini")
 })
 
+test("summarizeTelemetry prefers per-call data model over stale info model", () => {
+  const telemetry = summarizeTelemetry([
+    {
+      info: { role: "assistant", model: { providerID: "openai", modelID: "gpt-5.4" } },
+      data: { model: { providerID: "anthropic", modelID: "claude-sonnet-4-20250514" } },
+      tokens: { input: 1_000, output: 100, reasoning: 0, cache: { read: 500, write: 0 } },
+      cost: 0,
+    },
+  ])
+
+  expect(telemetry.perModelUsage).toHaveLength(1)
+  expect(telemetry.perModelUsage[0]?.providerID).toBe("anthropic")
+  expect(telemetry.perModelUsage[0]?.modelID).toBe("claude-sonnet-4-20250514")
+})
+
 test("ModelResolver reads scalar provider and model IDs from message data", () => {
   const resolver = new ModelResolver()
   const resolved = resolver.resolveModelAndProvider([
@@ -193,5 +208,40 @@ test("calculateCost uses the analysis pricing model when telemetry model metadat
 
   expect(cost.perModelCosts[0]?.pricingModelName).toBe("openai/gpt-5.4-mini")
   expect(cost.estimatedSessionCost).toBeCloseTo(0.0012)
+})
+
+test("calculateCost falls back when telemetry only has provider metadata", () => {
+  const calculator = new CostCalculator({
+    "openai/gpt-5.4-mini": { input: 0.75, output: 4.5, cacheWrite: 0, cacheRead: 0.075 },
+    default: { input: 1, output: 3, cacheWrite: 0, cacheRead: 0 },
+  })
+
+  const cost = calculator.calculateCost(
+    baseAnalysis({
+      pricingModelName: "openai/gpt-5.4-mini",
+      inputTokens: 1_000,
+      outputTokens: 100,
+      apiCallCount: 1,
+      perModelUsage: [
+        {
+          providerID: "openai",
+          modelName: "openai",
+          inputTokens: 1_000,
+          outputTokens: 100,
+          reasoningTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          apiCost: 0,
+          apiCallCount: 1,
+          callsWithCacheRead: 0,
+          callsWithCacheWrite: 0,
+        },
+      ],
+    })
+  )
+
+  expect(cost.perModelCosts[0]?.pricingModelName).toBe("openai/gpt-5.4-mini")
+  expect(cost.estimatedSessionCost).toBeCloseTo(0.0012)
+  expect(cost.unknownPricingModels).toEqual([])
 })
 

--- a/plugin/tokenscope-lib/analyzer.ts
+++ b/plugin/tokenscope-lib/analyzer.ts
@@ -122,7 +122,14 @@ export class ModelResolver {
   }
 
   private getProviderID(message: SessionMessage): string | undefined {
-    return message.info.providerID ?? message.info.model?.providerID ?? message.data?.model?.providerID ?? message.model?.providerID
+    return (
+      message.info.providerID ??
+      message.info.model?.providerID ??
+      message.data?.providerID ??
+      message.data?.model?.providerID ??
+      message.providerID ??
+      message.model?.providerID
+    )
   }
 
   private getModelID(message: SessionMessage): string | undefined {
@@ -130,8 +137,10 @@ export class ModelResolver {
       message.info.modelID ??
       message.info.model?.modelID ??
       message.info.model?.id ??
+      message.data?.modelID ??
       message.data?.model?.modelID ??
       message.data?.model?.id ??
+      message.modelID ??
       message.model?.modelID ??
       message.model?.id
     )

--- a/plugin/tokenscope-lib/analyzer.ts
+++ b/plugin/tokenscope-lib/analyzer.ts
@@ -122,11 +122,19 @@ export class ModelResolver {
   }
 
   private getProviderID(message: SessionMessage): string | undefined {
-    return message.info.providerID ?? message.info.model?.providerID
+    return message.info.providerID ?? message.info.model?.providerID ?? message.data?.model?.providerID ?? message.model?.providerID
   }
 
   private getModelID(message: SessionMessage): string | undefined {
-    return message.info.modelID ?? message.info.model?.modelID
+    return (
+      message.info.modelID ??
+      message.info.model?.modelID ??
+      message.info.model?.id ??
+      message.data?.model?.modelID ??
+      message.data?.model?.id ??
+      message.model?.modelID ??
+      message.model?.id
+    )
   }
 
   private canonicalize(value?: string): string | undefined {
@@ -344,6 +352,7 @@ export class TokenAnalysisEngine {
       mostRecentCost: 0,
       allToolsCalled,
       toolCallCounts,
+      perModelUsage: [],
       warnings: [],
     }
 
@@ -394,6 +403,7 @@ export class TokenAnalysisEngine {
     analysis.mostRecentCacheRead = telemetry.mostRecentCacheRead
     analysis.mostRecentCacheWrite = telemetry.mostRecentCacheWrite
     analysis.mostRecentProviderTotalTokens = telemetry.mostRecentProviderTotalTokens
+    analysis.perModelUsage = telemetry.perModelUsage
 
     const recentApiInputTotal = telemetry.mostRecentInput + telemetry.mostRecentCacheRead
     const localUserAndTools = analysis.categories.user.totalTokens + analysis.categories.tools.totalTokens

--- a/plugin/tokenscope-lib/cost.ts
+++ b/plugin/tokenscope-lib/cost.ts
@@ -51,8 +51,7 @@ export class CostCalculator {
     const usage = analysis.perModelUsage.length > 0 ? analysis.perModelUsage : [this.buildFallbackUsage(analysis)]
 
     return usage.map((modelUsage) => {
-      const pricingModelName =
-        this.buildLookupKey(modelUsage.providerID, modelUsage.modelID) || modelUsage.modelName || fallbackPricingModelName
+      const pricingModelName = this.resolvePricingModelName(modelUsage, fallbackPricingModelName)
       const pricing = this.getPricing(pricingModelName)
       const estimatedInputCost = (modelUsage.inputTokens / 1_000_000) * pricing.input
       const estimatedOutputCost = ((modelUsage.outputTokens + modelUsage.reasoningTokens) / 1_000_000) * pricing.output
@@ -75,6 +74,16 @@ export class CostCalculator {
         pricePerMillionCacheWrite: pricing.cacheWrite,
       }
     })
+  }
+
+  private resolvePricingModelName(modelUsage: ModelTokenUsage, fallbackPricingModelName: string): string {
+    const lookupKey = this.buildLookupKey(modelUsage.providerID, modelUsage.modelID)
+    if (lookupKey) return lookupKey
+
+    const modelName = modelUsage.modelName.trim()
+    if (modelName && modelName !== "unknown model") return modelName
+
+    return fallbackPricingModelName
   }
 
   private buildFallbackUsage(analysis: TokenAnalysis): ModelTokenUsage {

--- a/plugin/tokenscope-lib/cost.ts
+++ b/plugin/tokenscope-lib/cost.ts
@@ -76,11 +76,16 @@ export class CostCalculator {
     })
   }
 
-  private resolvePricingModelName(modelUsage: ModelTokenUsage, fallbackPricingModelName: string): string {
-    const lookupKey = this.buildLookupKey(modelUsage.providerID, modelUsage.modelID)
-    if (lookupKey) return lookupKey
+  resolvePricingModelName(modelUsage: ModelTokenUsage, fallbackPricingModelName: string): string {
+    const providerID = modelUsage.providerID?.trim()
+    const modelID = modelUsage.modelID?.trim()
+    const lookupKey = this.buildLookupKey(providerID, modelID)
+
+    if (providerID && modelID) return lookupKey
+    if (lookupKey && this.hasPricing(lookupKey)) return lookupKey
 
     const modelName = modelUsage.modelName.trim()
+    if (modelName === lookupKey) return fallbackPricingModelName
     if (modelName && modelName !== "unknown model") return modelName
 
     return fallbackPricingModelName

--- a/plugin/tokenscope-lib/cost.ts
+++ b/plugin/tokenscope-lib/cost.ts
@@ -1,12 +1,14 @@
 // CostCalculator - calculates costs from token analysis
 
-import type { TokenAnalysis, CostEstimate, ModelPricing } from "./types.js"
+import type { TokenAnalysis, CostEstimate, ModelCostEstimate, ModelPricing, ModelTokenUsage } from "./types.js"
 
 export class CostCalculator {
   constructor(private pricingData: Record<string, ModelPricing>) {}
 
   calculateCost(analysis: TokenAnalysis): CostEstimate {
-    const pricing = this.getPricing(analysis.pricingModelName ?? analysis.model.name)
+    const fallbackPricingModelName = analysis.pricingModelName ?? analysis.model.name
+    const perModelCosts = this.calculatePerModelCosts(analysis, fallbackPricingModelName)
+    const pricing = this.getPricing(fallbackPricingModelName)
     const hasActivity =
       analysis.apiCallCount > 0 &&
       (analysis.inputTokens > 0 ||
@@ -16,12 +18,11 @@ export class CostCalculator {
         analysis.cacheWriteTokens > 0)
     const isSubscription = hasActivity && analysis.sessionCost === 0
 
-    const estimatedInputCost = (analysis.inputTokens / 1_000_000) * pricing.input
-    const estimatedOutputCost = ((analysis.outputTokens + analysis.reasoningTokens) / 1_000_000) * pricing.output
-    const estimatedCacheReadCost = (analysis.cacheReadTokens / 1_000_000) * pricing.cacheRead
-    const estimatedCacheWriteCost = (analysis.cacheWriteTokens / 1_000_000) * pricing.cacheWrite
-    const estimatedSessionCost =
-      estimatedInputCost + estimatedOutputCost + estimatedCacheReadCost + estimatedCacheWriteCost
+    const estimatedInputCost = perModelCosts.reduce((sum, model) => sum + model.estimatedInputCost, 0)
+    const estimatedOutputCost = perModelCosts.reduce((sum, model) => sum + model.estimatedOutputCost, 0)
+    const estimatedCacheReadCost = perModelCosts.reduce((sum, model) => sum + model.estimatedCacheReadCost, 0)
+    const estimatedCacheWriteCost = perModelCosts.reduce((sum, model) => sum + model.estimatedCacheWriteCost, 0)
+    const estimatedSessionCost = perModelCosts.reduce((sum, model) => sum + model.estimatedSessionCost, 0)
 
     return {
       isSubscription,
@@ -41,6 +42,53 @@ export class CostCalculator {
       reasoningTokens: analysis.reasoningTokens,
       cacheReadTokens: analysis.cacheReadTokens,
       cacheWriteTokens: analysis.cacheWriteTokens,
+      perModelCosts,
+      unknownPricingModels: perModelCosts.filter((model) => !model.hasPricing).map((model) => model.pricingModelName),
+    }
+  }
+
+  private calculatePerModelCosts(analysis: TokenAnalysis, fallbackPricingModelName: string): ModelCostEstimate[] {
+    const usage = analysis.perModelUsage.length > 0 ? analysis.perModelUsage : [this.buildFallbackUsage(analysis)]
+
+    return usage.map((modelUsage) => {
+      const pricingModelName =
+        this.buildLookupKey(modelUsage.providerID, modelUsage.modelID) || modelUsage.modelName || fallbackPricingModelName
+      const pricing = this.getPricing(pricingModelName)
+      const estimatedInputCost = (modelUsage.inputTokens / 1_000_000) * pricing.input
+      const estimatedOutputCost = ((modelUsage.outputTokens + modelUsage.reasoningTokens) / 1_000_000) * pricing.output
+      const estimatedCacheReadCost = (modelUsage.cacheReadTokens / 1_000_000) * pricing.cacheRead
+      const estimatedCacheWriteCost = (modelUsage.cacheWriteTokens / 1_000_000) * pricing.cacheWrite
+
+      return {
+        ...modelUsage,
+        pricingModelName,
+        hasPricing: this.hasPricing(pricingModelName),
+        estimatedSessionCost:
+          estimatedInputCost + estimatedOutputCost + estimatedCacheReadCost + estimatedCacheWriteCost,
+        estimatedInputCost,
+        estimatedOutputCost,
+        estimatedCacheReadCost,
+        estimatedCacheWriteCost,
+        pricePerMillionInput: pricing.input,
+        pricePerMillionOutput: pricing.output,
+        pricePerMillionCacheRead: pricing.cacheRead,
+        pricePerMillionCacheWrite: pricing.cacheWrite,
+      }
+    })
+  }
+
+  private buildFallbackUsage(analysis: TokenAnalysis): ModelTokenUsage {
+    return {
+      modelName: analysis.pricingModelName ?? analysis.model.name,
+      inputTokens: analysis.inputTokens,
+      outputTokens: analysis.outputTokens,
+      reasoningTokens: analysis.reasoningTokens,
+      cacheReadTokens: analysis.cacheReadTokens,
+      cacheWriteTokens: analysis.cacheWriteTokens,
+      apiCost: analysis.sessionCost,
+      apiCallCount: analysis.apiCallCount,
+      callsWithCacheRead: analysis.callsWithCacheRead,
+      callsWithCacheWrite: analysis.callsWithCacheWrite,
     }
   }
 

--- a/plugin/tokenscope-lib/formatter.ts
+++ b/plugin/tokenscope-lib/formatter.ts
@@ -552,6 +552,7 @@ export class OutputFormatter {
   private formatCacheEfficiency(efficiency: CacheEfficiency, cost: CostEstimate, modelName: string): string[] {
     const lines: string[] = []
     const total = efficiency.totalInputTokens
+    const modelAwareEfficiency = this.calculateModelAwareCacheEfficiency(efficiency, cost)
 
     lines.push(``)
     lines.push(`\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550`)
@@ -583,22 +584,59 @@ export class OutputFormatter {
     lines.push(``)
 
     // Cost analysis
+    if (cost.perModelCosts.length > 1) {
+      lines.push(`  Cost Analysis (per-model pricing across ${cost.perModelCosts.length} models):`)
+      lines.push(`    Without caching:   $${modelAwareEfficiency.costWithoutCaching.toFixed(4)}`)
+      lines.push(`    With caching:      $${modelAwareEfficiency.costWithCaching.toFixed(4)}`)
+    } else {
+      lines.push(
+        `  Cost Analysis (${modelName} @ $${cost.pricePerMillionInput.toFixed(2)}/M input, $${cost.pricePerMillionCacheRead.toFixed(2)}/M cache read, $${cost.pricePerMillionCacheWrite.toFixed(2)}/M cache write):`
+      )
+      lines.push(
+        `    Without caching:   $${modelAwareEfficiency.costWithoutCaching.toFixed(4)}  (${this.formatNumber(total)} tokens x $${cost.pricePerMillionInput.toFixed(2)}/M)`
+      )
+      lines.push(
+        `    With caching:      $${modelAwareEfficiency.costWithCaching.toFixed(4)}  (fresh x $${cost.pricePerMillionInput.toFixed(2)}/M + cache read x $${cost.pricePerMillionCacheRead.toFixed(2)}/M + cache write x $${cost.pricePerMillionCacheWrite.toFixed(2)}/M)`
+      )
+    }
+    lines.push(`  ───────────────────────────────────────────────────────────────────`)
     lines.push(
-      `  Cost Analysis (${modelName} @ $${cost.pricePerMillionInput.toFixed(2)}/M input, $${cost.pricePerMillionCacheRead.toFixed(2)}/M cache read, $${cost.pricePerMillionCacheWrite.toFixed(2)}/M cache write):`
+      `  Cost Savings:        $${modelAwareEfficiency.costSavings.toFixed(4)}  (${modelAwareEfficiency.savingsPercent.toFixed(1)}% reduction)`
     )
     lines.push(
-      `    Without caching:   $${efficiency.costWithoutCaching.toFixed(4)}  (${this.formatNumber(total)} tokens x $${cost.pricePerMillionInput.toFixed(2)}/M)`
-    )
-    lines.push(
-      `    With caching:      $${efficiency.costWithCaching.toFixed(4)}  (fresh x $${cost.pricePerMillionInput.toFixed(2)}/M + cache read x $${cost.pricePerMillionCacheRead.toFixed(2)}/M + cache write x $${cost.pricePerMillionCacheWrite.toFixed(2)}/M)`
-    )
-    lines.push(`  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`)
-    lines.push(`  Cost Savings:        $${efficiency.costSavings.toFixed(4)}  (${efficiency.savingsPercent.toFixed(1)}% reduction)`)
-    lines.push(
-      `  Effective Rate:      $${efficiency.effectiveRate.toFixed(2)}/M tokens  (vs. $${efficiency.standardRate.toFixed(2)}/M standard)`
+      `  Effective Rate:      $${modelAwareEfficiency.effectiveRate.toFixed(2)}/M tokens  (vs. $${modelAwareEfficiency.standardRate.toFixed(2)}/M standard)`
     )
 
     return lines
+  }
+
+  private calculateModelAwareCacheEfficiency(efficiency: CacheEfficiency, cost: CostEstimate): CacheEfficiency {
+    if (cost.perModelCosts.length === 0) return efficiency
+
+    const costWithoutCaching = cost.perModelCosts.reduce((sum, modelCost) => {
+      const inputIfUncached = modelCost.inputTokens + modelCost.cacheReadTokens + modelCost.cacheWriteTokens
+      return sum + (inputIfUncached / 1_000_000) * modelCost.pricePerMillionInput
+    }, 0)
+    const costWithCaching = cost.perModelCosts.reduce(
+      (sum, modelCost) =>
+        sum + modelCost.estimatedInputCost + modelCost.estimatedCacheReadCost + modelCost.estimatedCacheWriteCost,
+      0
+    )
+    const costSavings = costWithoutCaching - costWithCaching
+    const savingsPercent = costWithoutCaching > 0 ? (costSavings / costWithoutCaching) * 100 : 0
+    const effectiveRate = efficiency.totalInputTokens > 0 ? (costWithCaching / efficiency.totalInputTokens) * 1_000_000 : 0
+    const standardRate =
+      efficiency.totalInputTokens > 0 ? (costWithoutCaching / efficiency.totalInputTokens) * 1_000_000 : efficiency.standardRate
+
+    return {
+      ...efficiency,
+      costWithoutCaching,
+      costWithCaching,
+      costSavings,
+      savingsPercent,
+      effectiveRate,
+      standardRate,
+    }
   }
 
   private formatEfficiencyBar(value: number, total: number): string {

--- a/plugin/tokenscope-lib/formatter.ts
+++ b/plugin/tokenscope-lib/formatter.ts
@@ -10,6 +10,7 @@ import type {
   CacheEfficiency,
   TokenscopeConfig,
   SkillAnalysis,
+  ModelCostEstimate,
 } from "./types.js"
 import { CostCalculator } from "./cost.js"
 
@@ -298,22 +299,7 @@ export class OutputFormatter {
       lines.push(`You appear to be on a subscription plan (API cost is $0).`)
       lines.push(`Here's what this session would cost with direct API access:`)
       lines.push(``)
-      lines.push(
-        `  Input tokens:      ${this.formatNumber(inputTokens).padStart(10)} \u00d7 $${cost.pricePerMillionInput.toFixed(2)}/M  = $${cost.estimatedInputCost.toFixed(4)}`
-      )
-      lines.push(
-        `  Output tokens:     ${this.formatNumber(outputTokens + reasoningTokens).padStart(10)} \u00d7 $${cost.pricePerMillionOutput.toFixed(2)}/M  = $${cost.estimatedOutputCost.toFixed(4)}`
-      )
-      if (cacheReadTokens > 0 && cost.pricePerMillionCacheRead > 0) {
-        lines.push(
-          `  Cache read:        ${this.formatNumber(cacheReadTokens).padStart(10)} \u00d7 $${cost.pricePerMillionCacheRead.toFixed(2)}/M  = $${cost.estimatedCacheReadCost.toFixed(4)}`
-        )
-      }
-      if (cacheWriteTokens > 0 && cost.pricePerMillionCacheWrite > 0) {
-        lines.push(
-          `  Cache write:       ${this.formatNumber(cacheWriteTokens).padStart(10)} \u00d7 $${cost.pricePerMillionCacheWrite.toFixed(2)}/M  = $${cost.estimatedCacheWriteCost.toFixed(4)}`
-        )
-      }
+      lines.push(...this.formatCostEstimateLines(cost))
       lines.push(`\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`)
       lines.push(`ESTIMATED TOTAL: $${cost.estimatedSessionCost.toFixed(4)}`)
       lines.push(``)
@@ -334,6 +320,11 @@ export class OutputFormatter {
       }
       if (cacheWriteTokens > 0) {
         lines.push(`  Cache write:       ${this.formatNumber(cacheWriteTokens).padStart(10)}`)
+      }
+      if (cost.perModelCosts.length > 1) {
+        lines.push(``)
+        lines.push(`Per-model estimated API pricing:`)
+        lines.push(...this.formatCostEstimateLines(cost))
       }
       lines.push(``)
       lines.push(`\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`)
@@ -761,6 +752,65 @@ export class OutputFormatter {
     lines.push(
       `  Note: Full task tool description is ~${this.formatNumber(analysis.taskToolDescriptionTokens)} tokens (includes instructions/examples).`
     )
+
+    return lines
+  }
+
+  private formatCostEstimateLines(cost: CostEstimate): string[] {
+    const hasMultipleModels = cost.perModelCosts.length > 1
+
+    if (!hasMultipleModels) {
+      return this.formatSingleModelCostLines(cost)
+    }
+
+    const lines: string[] = []
+    for (const modelCost of cost.perModelCosts) {
+      lines.push(
+        `  ${modelCost.modelName} (${modelCost.apiCallCount} call${modelCost.apiCallCount === 1 ? "" : "s"}): $${modelCost.estimatedSessionCost.toFixed(4)}`
+      )
+      if (!modelCost.hasPricing) {
+        lines.push(`    Pricing not found; used fallback default rates.`)
+      }
+      lines.push(...this.formatModelCostTokenLines(modelCost, "    "))
+    }
+
+    lines.push(``)
+    lines.push(`  Blended input:      $${cost.estimatedInputCost.toFixed(4)}`)
+    lines.push(`  Blended output:     $${cost.estimatedOutputCost.toFixed(4)}`)
+    if (cost.cacheReadTokens > 0) lines.push(`  Blended cache read: $${cost.estimatedCacheReadCost.toFixed(4)}`)
+    if (cost.cacheWriteTokens > 0) lines.push(`  Blended cache write: $${cost.estimatedCacheWriteCost.toFixed(4)}`)
+
+    return lines
+  }
+
+  private formatSingleModelCostLines(cost: CostEstimate): string[] {
+    const modelCost = cost.perModelCosts[0]
+    if (modelCost) return this.formatModelCostTokenLines(modelCost, "  ")
+
+    return [
+      `  Input tokens:      ${this.formatNumber(cost.inputTokens).padStart(10)} × $${cost.pricePerMillionInput.toFixed(2)}/M  = $${cost.estimatedInputCost.toFixed(4)}`,
+      `  Output tokens:     ${this.formatNumber(cost.outputTokens + cost.reasoningTokens).padStart(10)} × $${cost.pricePerMillionOutput.toFixed(2)}/M  = $${cost.estimatedOutputCost.toFixed(4)}`,
+    ]
+  }
+
+  private formatModelCostTokenLines(modelCost: ModelCostEstimate, indent: string): string[] {
+    const lines: string[] = []
+    lines.push(
+      `${indent}Input tokens:      ${this.formatNumber(modelCost.inputTokens).padStart(10)} × $${modelCost.pricePerMillionInput.toFixed(2)}/M  = $${modelCost.estimatedInputCost.toFixed(4)}`
+    )
+    lines.push(
+      `${indent}Output tokens:     ${this.formatNumber(modelCost.outputTokens + modelCost.reasoningTokens).padStart(10)} × $${modelCost.pricePerMillionOutput.toFixed(2)}/M  = $${modelCost.estimatedOutputCost.toFixed(4)}`
+    )
+    if (modelCost.cacheReadTokens > 0) {
+      lines.push(
+        `${indent}Cache read:        ${this.formatNumber(modelCost.cacheReadTokens).padStart(10)} × $${modelCost.pricePerMillionCacheRead.toFixed(2)}/M  = $${modelCost.estimatedCacheReadCost.toFixed(4)}`
+      )
+    }
+    if (modelCost.cacheWriteTokens > 0) {
+      lines.push(
+        `${indent}Cache write:       ${this.formatNumber(modelCost.cacheWriteTokens).padStart(10)} × $${modelCost.pricePerMillionCacheWrite.toFixed(2)}/M  = $${modelCost.estimatedCacheWriteCost.toFixed(4)}`
+      )
+    }
 
     return lines
   }

--- a/plugin/tokenscope-lib/subagent.ts
+++ b/plugin/tokenscope-lib/subagent.ts
@@ -102,8 +102,9 @@ export class SubagentAnalyzer {
       const assistantMessageCount = telemetry.assistantMessageCount
       const apiCallCount = telemetry.apiCallCount
       const totalTokens = inputTokens + outputTokens + reasoningTokens + cacheReadTokens + cacheWriteTokens
+      const fallbackPricingModelName = this.costCalculator.buildLookupKey(providerID, modelName) || modelName
       const estimatedCost = telemetry.perModelUsage.reduce((sum, modelUsage) => {
-        const pricingModelName = this.costCalculator.buildLookupKey(modelUsage.providerID, modelUsage.modelID) || modelUsage.modelName
+        const pricingModelName = this.costCalculator.resolvePricingModelName(modelUsage, fallbackPricingModelName)
         if (!this.costCalculator.hasPricing(pricingModelName)) {
           this.warnings?.add(
             `Pricing for child session model '${pricingModelName}' was not found in models.json. Subagent cost estimates for that model use the default fallback rates ($1/M input, $3/M output, no cache pricing).`,

--- a/plugin/tokenscope-lib/subagent.ts
+++ b/plugin/tokenscope-lib/subagent.ts
@@ -86,8 +86,11 @@ export class SubagentAnalyzer {
 
       for (const message of messages) {
         if (message.info.role !== "assistant") continue
-        if (message.info.providerID) providerID = message.info.providerID
-        if (message.info.modelID) modelName = message.info.modelID
+        const messageProviderID = message.info.providerID ?? message.info.model?.providerID
+        const messageModelID = message.info.modelID ?? message.info.model?.modelID ?? message.info.model?.id
+
+        if (messageProviderID) providerID = messageProviderID
+        if (messageModelID) modelName = messageModelID
       }
 
       const inputTokens = telemetry.inputTokens
@@ -99,13 +102,17 @@ export class SubagentAnalyzer {
       const assistantMessageCount = telemetry.assistantMessageCount
       const apiCallCount = telemetry.apiCallCount
       const totalTokens = inputTokens + outputTokens + reasoningTokens + cacheReadTokens + cacheWriteTokens
-      const pricingModelName = this.costCalculator.buildLookupKey(providerID, modelName) || modelName
-      const pricing = this.costCalculator.getPricing(pricingModelName)
-      const estimatedCost =
-        (inputTokens / 1_000_000) * pricing.input +
-        ((outputTokens + reasoningTokens) / 1_000_000) * pricing.output +
-        (cacheReadTokens / 1_000_000) * pricing.cacheRead +
-        (cacheWriteTokens / 1_000_000) * pricing.cacheWrite
+      const estimatedCost = telemetry.perModelUsage.reduce((sum, modelUsage) => {
+        const pricingModelName = this.costCalculator.buildLookupKey(modelUsage.providerID, modelUsage.modelID) || modelUsage.modelName
+        const pricing = this.costCalculator.getPricing(pricingModelName)
+        return (
+          sum +
+          (modelUsage.inputTokens / 1_000_000) * pricing.input +
+          ((modelUsage.outputTokens + modelUsage.reasoningTokens) / 1_000_000) * pricing.output +
+          (modelUsage.cacheReadTokens / 1_000_000) * pricing.cacheRead +
+          (modelUsage.cacheWriteTokens / 1_000_000) * pricing.cacheWrite
+        )
+      }, 0)
 
       return {
         sessionID: child.id,

--- a/plugin/tokenscope-lib/subagent.ts
+++ b/plugin/tokenscope-lib/subagent.ts
@@ -104,6 +104,12 @@ export class SubagentAnalyzer {
       const totalTokens = inputTokens + outputTokens + reasoningTokens + cacheReadTokens + cacheWriteTokens
       const estimatedCost = telemetry.perModelUsage.reduce((sum, modelUsage) => {
         const pricingModelName = this.costCalculator.buildLookupKey(modelUsage.providerID, modelUsage.modelID) || modelUsage.modelName
+        if (!this.costCalculator.hasPricing(pricingModelName)) {
+          this.warnings?.add(
+            `Pricing for child session model '${pricingModelName}' was not found in models.json. Subagent cost estimates for that model use the default fallback rates ($1/M input, $3/M output, no cache pricing).`,
+            `missing-subagent-pricing:${pricingModelName}`
+          )
+        }
         const pricing = this.costCalculator.getPricing(pricingModelName)
         return (
           sum +

--- a/plugin/tokenscope-lib/telemetry.ts
+++ b/plugin/tokenscope-lib/telemetry.ts
@@ -92,12 +92,34 @@ function getMessageRole(message: TelemetryMessageLike): string | undefined {
 }
 
 function getModelRef(message: TelemetryMessageLike, part?: TelemetryPartLike): ModelRefLike {
-  const source = part?.model ?? message.info?.model ?? message.data?.model ?? message.model ?? {}
+  const partModel = part?.model
+  const dataModel = message.data?.model
+  const infoModel = message.info?.model
+  const topLevelModel = message.model
+
   return {
     providerID: normalizeString(
-      source.providerID ?? message.info?.providerID ?? message.data?.providerID ?? message.providerID
+      partModel?.providerID ??
+        dataModel?.providerID ??
+        message.data?.providerID ??
+        infoModel?.providerID ??
+        message.info?.providerID ??
+        topLevelModel?.providerID ??
+        message.providerID
     ),
-    modelID: normalizeString(source.modelID ?? source.id ?? message.info?.modelID ?? message.data?.modelID ?? message.modelID),
+    modelID: normalizeString(
+      partModel?.modelID ??
+        partModel?.id ??
+        dataModel?.modelID ??
+        dataModel?.id ??
+        message.data?.modelID ??
+        infoModel?.modelID ??
+        infoModel?.id ??
+        message.info?.modelID ??
+        topLevelModel?.modelID ??
+        topLevelModel?.id ??
+        message.modelID
+    ),
   }
 }
 

--- a/plugin/tokenscope-lib/telemetry.ts
+++ b/plugin/tokenscope-lib/telemetry.ts
@@ -67,6 +67,8 @@ type TelemetryMessageLike = {
   }
   role?: string
   type?: string
+  providerID?: string
+  modelID?: string
   tokens?: TokenUsage
   cost?: number
   model?: ModelRefLike
@@ -92,8 +94,10 @@ function getMessageRole(message: TelemetryMessageLike): string | undefined {
 function getModelRef(message: TelemetryMessageLike, part?: TelemetryPartLike): ModelRefLike {
   const source = part?.model ?? message.info?.model ?? message.data?.model ?? message.model ?? {}
   return {
-    providerID: normalizeString(source.providerID ?? message.info?.providerID ?? message.data?.providerID),
-    modelID: normalizeString(source.modelID ?? source.id ?? message.info?.modelID ?? message.data?.modelID),
+    providerID: normalizeString(
+      source.providerID ?? message.info?.providerID ?? message.data?.providerID ?? message.providerID
+    ),
+    modelID: normalizeString(source.modelID ?? source.id ?? message.info?.modelID ?? message.data?.modelID ?? message.modelID),
   }
 }
 

--- a/plugin/tokenscope-lib/telemetry.ts
+++ b/plugin/tokenscope-lib/telemetry.ts
@@ -1,8 +1,10 @@
 // Telemetry helpers - extracts per-API-call token and cost data from stored session messages
 
-import type { TokenUsage } from "./types.js"
+import type { ModelTokenUsage, TokenUsage } from "./types.js"
 
 export interface TelemetryCall {
+  providerID?: string
+  modelID?: string
   inputTokens: number
   outputTokens: number
   reasoningTokens: number
@@ -30,21 +32,45 @@ export interface TelemetrySummary {
   mostRecentCacheWrite: number
   mostRecentCost: number
   mostRecentProviderTotalTokens?: number
+  perModelUsage: ModelTokenUsage[]
+}
+
+type ModelRefLike = {
+  providerID?: string
+  modelID?: string
+  id?: string
 }
 
 type TelemetryPartLike = {
   type?: string
   tokens?: TokenUsage
   cost?: number
+  model?: ModelRefLike
 }
 
 type TelemetryMessageLike = {
-  info: {
+  info?: {
     role?: string
     tokens?: TokenUsage
     cost?: number
+    providerID?: string
+    modelID?: string
+    model?: ModelRefLike
   }
-  parts: TelemetryPartLike[]
+  data?: {
+    role?: string
+    tokens?: TokenUsage
+    cost?: number
+    providerID?: string
+    modelID?: string
+    model?: ModelRefLike
+  }
+  role?: string
+  type?: string
+  tokens?: TokenUsage
+  cost?: number
+  model?: ModelRefLike
+  parts?: TelemetryPartLike[]
 }
 
 function safeNumber(value: unknown): number {
@@ -55,7 +81,36 @@ function hasExplicitNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value)
 }
 
-function buildTelemetryCall(tokens: TokenUsage | undefined, cost: unknown, force: boolean): TelemetryCall | null {
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined
+}
+
+function getMessageRole(message: TelemetryMessageLike): string | undefined {
+  return message.info?.role ?? message.data?.role ?? message.role ?? message.type
+}
+
+function getModelRef(message: TelemetryMessageLike, part?: TelemetryPartLike): ModelRefLike {
+  const source = part?.model ?? message.info?.model ?? message.data?.model ?? message.model ?? {}
+  return {
+    providerID: normalizeString(source.providerID ?? message.info?.providerID ?? message.data?.providerID),
+    modelID: normalizeString(source.modelID ?? source.id ?? message.info?.modelID ?? message.data?.modelID),
+  }
+}
+
+function getMessageTokens(message: TelemetryMessageLike): TokenUsage | undefined {
+  return message.info?.tokens ?? message.data?.tokens ?? message.tokens
+}
+
+function getMessageCost(message: TelemetryMessageLike): unknown {
+  return message.info?.cost ?? message.data?.cost ?? message.cost
+}
+
+function buildTelemetryCall(
+  tokens: TokenUsage | undefined,
+  cost: unknown,
+  force: boolean,
+  model: ModelRefLike
+): TelemetryCall | null {
   const inputTokens = safeNumber(tokens?.input)
   const outputTokens = safeNumber(tokens?.output)
   const reasoningTokens = safeNumber(tokens?.reasoning)
@@ -72,6 +127,8 @@ function buildTelemetryCall(tokens: TokenUsage | undefined, cost: unknown, force
   if (!force && !hasActivity) return null
 
   return {
+    providerID: model.providerID,
+    modelID: model.modelID,
     inputTokens,
     outputTokens,
     reasoningTokens,
@@ -86,22 +143,67 @@ function isStepFinishPart(part: TelemetryPartLike): part is Required<Pick<Teleme
   return part.type === "step-finish"
 }
 
+function modelDisplayName(providerID?: string, modelID?: string): string {
+  if (providerID && modelID) return `${providerID}/${modelID}`
+  return modelID ?? providerID ?? "unknown model"
+}
+
+function modelGroupingKey(providerID?: string, modelID?: string): string {
+  return `${providerID ?? ""}\u0000${modelID ?? ""}`
+}
+
+function summarizeCallsByModel(calls: TelemetryCall[]): ModelTokenUsage[] {
+  const byModel = new Map<string, ModelTokenUsage>()
+
+  for (const call of calls) {
+    const key = modelGroupingKey(call.providerID, call.modelID)
+    const existing = byModel.get(key) ?? {
+      providerID: call.providerID,
+      modelID: call.modelID,
+      modelName: modelDisplayName(call.providerID, call.modelID),
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      apiCost: 0,
+      apiCallCount: 0,
+      callsWithCacheRead: 0,
+      callsWithCacheWrite: 0,
+    }
+
+    existing.inputTokens += call.inputTokens
+    existing.outputTokens += call.outputTokens
+    existing.reasoningTokens += call.reasoningTokens
+    existing.cacheReadTokens += call.cacheReadTokens
+    existing.cacheWriteTokens += call.cacheWriteTokens
+    existing.apiCost += call.cost
+    existing.apiCallCount += 1
+    if (call.cacheReadTokens > 0) existing.callsWithCacheRead += 1
+    if (call.cacheWriteTokens > 0) existing.callsWithCacheWrite += 1
+
+    byModel.set(key, existing)
+  }
+
+  return Array.from(byModel.values()).sort((a, b) => b.apiCallCount - a.apiCallCount || a.modelName.localeCompare(b.modelName))
+}
+
 export function collectTelemetryCalls(messages: TelemetryMessageLike[]): TelemetryCall[] {
   const calls: TelemetryCall[] = []
 
   for (const message of messages) {
-    if (message.info.role !== "assistant") continue
+    if (getMessageRole(message) !== "assistant") continue
 
-    const stepFinishParts = message.parts.filter(isStepFinishPart)
+    const stepFinishParts = (message.parts ?? []).filter(isStepFinishPart)
     if (stepFinishParts.length > 0) {
       for (const part of stepFinishParts) {
-        const call = buildTelemetryCall(part.tokens, part.cost, true)
+        const call = buildTelemetryCall(part.tokens, part.cost, true, getModelRef(message, part))
         if (call) calls.push(call)
       }
       continue
     }
 
-    const fallback = buildTelemetryCall(message.info.tokens, message.info.cost, false)
+    const fallback = buildTelemetryCall(getMessageTokens(message), getMessageCost(message), false, getModelRef(message))
     if (fallback) calls.push(fallback)
   }
 
@@ -109,7 +211,7 @@ export function collectTelemetryCalls(messages: TelemetryMessageLike[]): Telemet
 }
 
 export function summarizeTelemetry(messages: TelemetryMessageLike[]): TelemetrySummary {
-  const assistantMessageCount = messages.reduce((count, message) => count + (message.info.role === "assistant" ? 1 : 0), 0)
+  const assistantMessageCount = messages.reduce((count, message) => count + (getMessageRole(message) === "assistant" ? 1 : 0), 0)
   const calls = collectTelemetryCalls(messages)
 
   let inputTokens = 0
@@ -153,6 +255,7 @@ export function summarizeTelemetry(messages: TelemetryMessageLike[]): TelemetryS
     mostRecentCacheWrite: mostRecent?.cacheWriteTokens ?? 0,
     mostRecentCost: mostRecent?.cost ?? 0,
     mostRecentProviderTotalTokens: mostRecent?.providerTotalTokens,
+    perModelUsage: summarizeCallsByModel(calls),
   }
 }
 

--- a/plugin/tokenscope-lib/types.ts
+++ b/plugin/tokenscope-lib/types.ts
@@ -20,6 +20,8 @@ export interface SessionMessage {
     modelID?: string
     id?: string
   }
+  providerID?: string
+  modelID?: string
 }
 
 export interface SessionMessageInfo {

--- a/plugin/tokenscope-lib/types.ts
+++ b/plugin/tokenscope-lib/types.ts
@@ -3,6 +3,23 @@
 export interface SessionMessage {
   info: SessionMessageInfo
   parts: SessionMessagePart[]
+  data?: {
+    role?: string
+    model?: {
+      providerID?: string
+      modelID?: string
+      id?: string
+    }
+    providerID?: string
+    modelID?: string
+    tokens?: TokenUsage
+    cost?: number
+  }
+  model?: {
+    providerID?: string
+    modelID?: string
+    id?: string
+  }
 }
 
 export interface SessionMessageInfo {
@@ -12,6 +29,7 @@ export interface SessionMessageInfo {
   model?: {
     providerID?: string
     modelID?: string
+    id?: string
   }
   modelID?: string
   providerID?: string
@@ -93,6 +111,7 @@ export interface TokenAnalysis {
   mostRecentCost: number
   allToolsCalled: string[]
   toolCallCounts: Map<string, number>
+  perModelUsage: ModelTokenUsage[]
   warnings: string[]
   subagentAnalysis?: SubagentAnalysis
   // New context analysis fields
@@ -135,6 +154,37 @@ export interface CostEstimate {
   reasoningTokens: number
   cacheReadTokens: number
   cacheWriteTokens: number
+  perModelCosts: ModelCostEstimate[]
+  unknownPricingModels: string[]
+}
+
+export interface ModelTokenUsage {
+  providerID?: string
+  modelID?: string
+  modelName: string
+  inputTokens: number
+  outputTokens: number
+  reasoningTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  apiCost: number
+  apiCallCount: number
+  callsWithCacheRead: number
+  callsWithCacheWrite: number
+}
+
+export interface ModelCostEstimate extends ModelTokenUsage {
+  pricingModelName: string
+  hasPricing: boolean
+  estimatedSessionCost: number
+  estimatedInputCost: number
+  estimatedOutputCost: number
+  estimatedCacheReadCost: number
+  estimatedCacheWriteCost: number
+  pricePerMillionInput: number
+  pricePerMillionOutput: number
+  pricePerMillionCacheRead: number
+  pricePerMillionCacheWrite: number
 }
 
 export interface SubagentSummary {

--- a/plugin/tokenscope.ts
+++ b/plugin/tokenscope.ts
@@ -150,7 +150,7 @@ export const TokenAnalyzerPlugin: Plugin = async ({ client, serverUrl, directory
             analysis.pricingModelName = pricingModelName
 
             for (const modelUsage of analysis.perModelUsage) {
-              const modelPricingName = costCalculator.buildLookupKey(modelUsage.providerID, modelUsage.modelID) || modelUsage.modelName
+              const modelPricingName = costCalculator.resolvePricingModelName(modelUsage, pricingModelName)
               if (!costCalculator.hasPricing(modelPricingName)) {
                 warnings.add(
                   `Pricing for '${modelPricingName}' was not found in models.json. Cost estimates for that model use the default fallback rates ($1/M input, $3/M output, no cache pricing).`,

--- a/plugin/tokenscope.ts
+++ b/plugin/tokenscope.ts
@@ -149,6 +149,16 @@ export const TokenAnalyzerPlugin: Plugin = async ({ client, serverUrl, directory
             )
             analysis.pricingModelName = pricingModelName
 
+            for (const modelUsage of analysis.perModelUsage) {
+              const modelPricingName = costCalculator.buildLookupKey(modelUsage.providerID, modelUsage.modelID) || modelUsage.modelName
+              if (!costCalculator.hasPricing(modelPricingName)) {
+                warnings.add(
+                  `Pricing for '${modelPricingName}' was not found in models.json. Cost estimates for that model use the default fallback rates ($1/M input, $3/M output, no cache pricing).`,
+                  `missing-pricing:${modelPricingName}`
+                )
+              }
+            }
+
             // Subagent analysis (respects config)
             const shouldIncludeSubagents = args.includeSubagents !== false && config.enableSubagentAnalysis
             if (shouldIncludeSubagents) {


### PR DESCRIPTION
## Summary
- aggregate telemetry per assistant-message model, including cache read/write and reasoning buckets
- calculate estimated costs per model with model-specific pricing for each token type
- surface per-model cost lines and warnings for missing pricing; apply same attribution to subagents

Fixes #33

## Validation
- npm run typecheck
- npx bun test
- npm run build && node -e "await import('./dist/tokenscope.js')"
- headless opencode run across openai/gpt-5.4-mini and openai/gpt-5.4, then --command tokenscope; report showed per-model costs and cache-read attribution