### PR TITLE
Align TokenScope with current OpenCode APIs

### DIFF
--- a/plugin/test/context.test.ts
+++ b/plugin/test/context.test.ts
@@ -1,0 +1,155 @@
+import { expect, test } from "bun:test"
+
+import { ContextAnalyzer } from "../tokenscope-lib/context.js"
+import type { ExportedSession, TokenModel } from "../tokenscope-lib/types.js"
+
+const tokenModel: TokenModel = { name: "test", spec: { kind: "approx" } }
+
+const tokenizer = {
+  async countTokens(content: string) {
+    return content.trim().split(/\s+/).filter(Boolean).length
+  },
+} as any
+
+test("context breakdown ignores user system overrides as generated OpenCode context", async () => {
+  const analyzer = new ContextAnalyzer(tokenizer)
+  const exported: ExportedSession = {
+    info: { id: "ses_test", title: "test" },
+    messages: [
+      {
+        info: { id: "msg_user", role: "user", system: "You are a terse assistant." },
+        parts: [{ type: "text" }],
+      },
+      {
+        info: { id: "msg_assistant", role: "assistant" },
+        parts: [
+          {
+            type: "step-finish",
+            tokens: { input: 100, output: 10, cache: { read: 0, write: 2_000 }, reasoning: 0 },
+          } as any,
+        ],
+      },
+    ],
+  }
+
+  const breakdown = await (analyzer as any).analyzeContextBreakdown(exported, tokenModel, [
+    { id: "read", description: "Read files", parameters: { type: "object", properties: { filePath: { type: "string" } } } },
+  ])
+
+  expect(breakdown.totalCachedContext).toBe(2_000)
+  expect(breakdown.baseSystemPrompt.tokens).toBeGreaterThan(0)
+  expect(breakdown.toolDefinitions.toolCount).toBe(1)
+})
+
+test("context breakdown preserves generated base prompt fragments and merges tool metadata", async () => {
+  const analyzer = new ContextAnalyzer(tokenizer)
+  const exported: ExportedSession = {
+    info: { id: "ses_test", title: "test" },
+    messages: [
+      {
+        info: {
+          id: "msg_user",
+          role: "user",
+          tools: { read: true, write: false },
+          system: [
+            "You are opencode, an AI coding agent built for software engineering tasks. Follow project instructions carefully.",
+            "<env>\nWorking directory: /tmp/project\nPlatform: darwin\n</env>",
+          ],
+        },
+        parts: [{ type: "text" }],
+      },
+    ],
+  }
+  const tools = [
+    { id: "read", description: "Read files", parameters: { type: "object", properties: { filePath: { type: "string" } } } },
+    { id: "write", description: "Write files", parameters: { type: "object", properties: { filePath: { type: "string" } } } },
+  ]
+
+  await (analyzer as any).precomputeToolDefinitionTokens(tools, tokenModel)
+  const breakdown = await (analyzer as any).analyzeContextBreakdown(exported, tokenModel, tools)
+
+  expect(breakdown.baseSystemPrompt.tokens).toBeGreaterThan(0)
+  expect(breakdown.environmentContext.tokens).toBeGreaterThan(0)
+  expect(breakdown.toolDefinitions.toolCount).toBe(2)
+  expect(breakdown.toolDefinitions.tokens).toBeGreaterThan(0)
+})
+
+test("tool schema estimates keep current OpenCode tool metadata visible despite permission overrides", async () => {
+  const analyzer = new ContextAnalyzer(tokenizer)
+  const exported: ExportedSession = {
+    info: { id: "ses_test", title: "test" },
+    messages: [
+      {
+        info: { id: "msg_user", role: "user", tools: { read: true, write: false } },
+        parts: [{ type: "text" }],
+      },
+    ],
+  }
+
+  const estimates = await (analyzer as any).estimateToolSchemas(exported, tokenModel, [
+    { id: "read", description: "Read files", parameters: { type: "object", properties: { filePath: { type: "string" } } } },
+    { id: "write", description: "Write files", parameters: { type: "object", properties: { filePath: { type: "string" } } } },
+  ])
+
+  expect(estimates.find((estimate: any) => estimate.name === "read")?.enabled).toBe(true)
+  expect(estimates.find((estimate: any) => estimate.name === "write")?.enabled).toBe(true)
+})
+
+test("single env-like user override still falls back to cache telemetry", async () => {
+  const analyzer = new ContextAnalyzer(tokenizer)
+  const exported: ExportedSession = {
+    info: { id: "ses_test", title: "test" },
+    messages: [
+      {
+        info: { id: "msg_user", role: "user", system: "<env>\nPlease explain what this XML tag means.\n</env>" },
+        parts: [{ type: "text" }],
+      },
+      {
+        info: { id: "msg_assistant", role: "assistant" },
+        parts: [
+          {
+            type: "step-finish",
+            tokens: { input: 100, output: 10, cache: { read: 0, write: 2_000 }, reasoning: 0 },
+          } as any,
+        ],
+      },
+    ],
+  }
+
+  const breakdown = await (analyzer as any).analyzeContextBreakdown(exported, tokenModel, [])
+
+  expect(breakdown.totalCachedContext).toBe(2_000)
+  expect(breakdown.environmentContext.identified).toBe(false)
+})
+
+test("context analysis selects the model from the first cache write call", () => {
+  const analyzer = new ContextAnalyzer(tokenizer)
+  const exported: ExportedSession = {
+    info: { id: "ses_test", title: "test" },
+    messages: [
+      {
+        info: { id: "msg_first", role: "assistant", model: { providerID: "anthropic", modelID: "claude-sonnet-4-20250514" } },
+        parts: [
+          {
+            type: "step-finish",
+            tokens: { input: 100, output: 10, cache: { read: 0, write: 2_000 }, reasoning: 0 },
+          } as any,
+        ],
+      },
+      {
+        info: { id: "msg_second", role: "assistant", model: { providerID: "openai", modelID: "gpt-5.4-mini" } },
+        parts: [
+          {
+            type: "step-finish",
+            tokens: { input: 100, output: 10, cache: { read: 2_000, write: 0 }, reasoning: 0 },
+          } as any,
+        ],
+      },
+    ],
+  }
+
+  expect((analyzer as any).firstCacheWriteModel(exported)).toEqual({
+    providerID: "anthropic",
+    modelID: "claude-sonnet-4-20250514",
+  })
+})

--- a/plugin/test/opencode.test.ts
+++ b/plugin/test/opencode.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test"
+
+import { fetchSessionMessages, fetchToolList } from "../tokenscope-lib/opencode.js"
+
+test("fetchSessionMessages falls back to the current SDK parameter shape", async () => {
+  const calls: unknown[] = []
+  const client = {
+    session: {
+      async messages(input: unknown, options?: unknown) {
+        calls.push(options === undefined ? input : [input, options])
+        if ((input as any)?.sessionID === "ses_current") return [{ ok: true }]
+        throw new Error("bad shape")
+      },
+    },
+  }
+
+  const messages = await fetchSessionMessages(client, "ses_current")
+
+  expect(messages).toEqual([{ ok: true }])
+  expect(calls).toEqual([
+    { path: { id: "ses_current" }, throwOnError: true },
+    { path: { sessionID: "ses_current" }, throwOnError: true },
+    [{ sessionID: "ses_current" }, { throwOnError: true }],
+  ])
+})
+
+test("fetchSessionMessages continues past non-throwing error responses", async () => {
+  const client = {
+    session: {
+      async messages(input: unknown) {
+        if ((input as any)?.sessionID === "ses_current") return [{ ok: true }]
+        return { error: { message: "not found" } }
+      },
+    },
+  }
+
+  await expect(fetchSessionMessages(client, "ses_current")).resolves.toEqual([{ ok: true }])
+})
+
+test("fetchToolList supports legacy and current SDK parameter shapes", async () => {
+  const calls: unknown[] = []
+  const client = {
+    tool: {
+      async list(input: unknown, options?: unknown) {
+        calls.push(options === undefined ? input : [input, options])
+        if ((input as any)?.provider === "anthropic" && (input as any)?.model === "claude-sonnet-4-20250514") {
+          return [{ id: "read" }]
+        }
+        throw new Error("bad shape")
+      },
+    },
+  }
+
+  const tools = await fetchToolList(client, "anthropic", "claude-sonnet-4-20250514")
+
+  expect(tools).toEqual([{ id: "read" }])
+  expect(calls).toEqual([
+    { query: { provider: "anthropic", model: "claude-sonnet-4-20250514" }, throwOnError: true },
+    [{ provider: "anthropic", model: "claude-sonnet-4-20250514" }, { throwOnError: true }],
+  ])
+})
+
+test("fetchToolList continues past non-throwing error responses", async () => {
+  const client = {
+    tool: {
+      async list(input: unknown) {
+        if ((input as any)?.provider === "anthropic") return [{ id: "read" }]
+        return { error: { message: "bad query" } }
+      },
+    },
+  }
+
+  await expect(fetchToolList(client, "anthropic", "claude-sonnet-4-20250514")).resolves.toEqual([{ id: "read" }])
+})
+
+test("fetchToolList forwards workspace routing parameters", async () => {
+  const calls: unknown[] = []
+  const client = {
+    tool: {
+      async list(input: unknown) {
+        calls.push(input)
+        return [{ id: "read" }]
+      },
+    },
+  }
+
+  await fetchToolList(client, "anthropic", "claude-sonnet-4-20250514", { directory: "/tmp/project" })
+
+  expect(calls[0]).toEqual({
+    query: { directory: "/tmp/project", provider: "anthropic", model: "claude-sonnet-4-20250514" },
+    throwOnError: true,
+  })
+})

--- a/plugin/tokenscope-lib/context.ts
+++ b/plugin/tokenscope-lib/context.ts
@@ -14,15 +14,26 @@ import type {
   ContextAnalysisResult,
 } from "./types.js"
 import { TokenizerManager } from "./tokenizer.js"
-import { firstCacheWriteTokens, summarizeTelemetry } from "./telemetry.js"
+import { collectTelemetryCalls, firstCacheWriteTokens, summarizeTelemetry } from "./telemetry.js"
 import { WarningCollector, formatErrorMessage } from "./warnings.js"
+import { fetchToolList, unwrapResponseData } from "./opencode.js"
+
+interface ToolListItem {
+  id: string
+  description?: string
+  parameters?: unknown
+  jsonSchema?: unknown
+}
 
 export class ContextAnalyzer {
   private tokenizerManager: TokenizerManager
+  private toolTokenCache = new WeakMap<ToolListItem, number>()
 
   constructor(
     tokenizerManager: TokenizerManager,
-    private warnings?: WarningCollector
+    private warnings?: WarningCollector,
+    private client?: any,
+    private directory?: string
   ) {
     this.tokenizerManager = tokenizerManager
   }
@@ -34,7 +45,9 @@ export class ContextAnalyzer {
     sessionID: string,
     tokenModel: TokenModel,
     pricing: ModelPricing,
-    config: TokenscopeConfig
+    config: TokenscopeConfig,
+    providerID?: string,
+    modelID?: string
   ): Promise<ContextAnalysisResult> {
     const result: ContextAnalysisResult = {}
 
@@ -42,12 +55,21 @@ export class ContextAnalyzer {
       const exported = await this.runExport(sessionID)
       if (!exported) return result
 
+      const shouldFetchToolDefinitions = config.enableContextBreakdown || config.enableToolSchemaEstimation
+      const cacheWriteModel = this.firstCacheWriteModel(exported)
+      const toolProviderID = cacheWriteModel.providerID ?? providerID
+      const toolModelID = cacheWriteModel.modelID ?? modelID
+      const toolDefinitions = shouldFetchToolDefinitions ? await this.getToolDefinitions(toolProviderID, toolModelID) : []
+      if (toolDefinitions.length > 0) {
+        await this.precomputeToolDefinitionTokens(toolDefinitions, tokenModel)
+      }
+
       if (config.enableContextBreakdown) {
-        result.contextBreakdown = await this.analyzeContextBreakdown(exported, tokenModel)
+        result.contextBreakdown = await this.analyzeContextBreakdown(exported, tokenModel, toolDefinitions)
       }
 
       if (config.enableToolSchemaEstimation) {
-        result.toolEstimates = this.estimateToolSchemas(exported)
+        result.toolEstimates = await this.estimateToolSchemas(exported, tokenModel, toolDefinitions)
       }
 
       if (config.enableCacheEfficiency) {
@@ -101,7 +123,8 @@ export class ContextAnalyzer {
    */
   private async analyzeContextBreakdown(
     exported: ExportedSession,
-    tokenModel: TokenModel
+    tokenModel: TokenModel,
+    toolDefinitions: ToolListItem[]
   ): Promise<ContextBreakdown> {
     const breakdown: ContextBreakdown = {
       baseSystemPrompt: { tokens: 0, identified: false },
@@ -112,16 +135,19 @@ export class ContextAnalyzer {
       totalCachedContext: 0,
     }
 
-    // Try to get system prompts from export (for future compatibility)
-    const systemPrompts = this.extractSystemPrompts(exported)
+    // OpenCode currently stores only explicit user-provided system overrides on
+    // messages, not the generated env/instructions/skills/tool prompt array.
+    // Only tokenize exported system content directly if it looks like generated
+    // OpenCode context; otherwise estimate from provider cache_write telemetry.
+    const systemPrompts = this.selectGeneratedSystemPrompts(this.extractSystemPrompts(exported))
 
     // If system prompts are available, analyze them directly
     if (systemPrompts.length > 0) {
-      return this.analyzeSystemPromptContent(exported, tokenModel, systemPrompts, breakdown)
+      return this.analyzeSystemPromptContent(exported, tokenModel, systemPrompts, breakdown, toolDefinitions)
     }
 
     // Default: Estimate from cache_write tokens
-    return this.estimateContextFromCacheTokens(exported, breakdown)
+    return this.estimateContextFromCacheTokens(exported, breakdown, toolDefinitions)
   }
 
   /**
@@ -131,7 +157,8 @@ export class ContextAnalyzer {
     exported: ExportedSession,
     tokenModel: TokenModel,
     systemPrompts: string[],
-    breakdown: ContextBreakdown
+    breakdown: ContextBreakdown,
+    toolDefinitions: ToolListItem[]
   ): Promise<ContextBreakdown> {
 
     for (const prompt of systemPrompts) {
@@ -258,6 +285,13 @@ export class ContextAnalyzer {
       breakdown.projectTree.tokens +
       breakdown.customInstructions.tokens
 
+    if (breakdown.toolDefinitions.tokens === 0 && toolDefinitions.length > 0) {
+      breakdown.toolDefinitions.tokens = this.sumPrecomputedToolTokens(toolDefinitions)
+      breakdown.toolDefinitions.toolCount = toolDefinitions.length
+      breakdown.toolDefinitions.identified = false
+      breakdown.totalCachedContext += breakdown.toolDefinitions.tokens
+    }
+
     return breakdown
   }
 
@@ -314,7 +348,8 @@ export class ContextAnalyzer {
    */
   private estimateContextFromCacheTokens(
     exported: ExportedSession,
-    breakdown: ContextBreakdown
+    breakdown: ContextBreakdown,
+    toolDefinitions: ToolListItem[]
   ): ContextBreakdown {
     // Find the first API call that wrote to cache to estimate total cached context size
     const totalCachedTokens = firstCacheWriteTokens(exported.messages)
@@ -322,14 +357,16 @@ export class ContextAnalyzer {
 
     // Count enabled tools from tool calls
     const enabledTools = this.extractEnabledTools(exported)
-    enabledToolCount = Object.keys(enabledTools).length
+    enabledToolCount = toolDefinitions.length || Object.values(enabledTools).filter(Boolean).length
 
     if (totalCachedTokens === 0) {
       return breakdown
     }
 
-    // Estimate tool definitions (~350 tokens per tool)
-    const estimatedToolTokens = enabledToolCount * 350
+    const measuredToolTokens = this.sumPrecomputedToolTokens(toolDefinitions)
+    // Prefer current OpenCode /experimental/tool metadata when available; fall
+    // back to a coarse per-tool estimate when only transcript data is present.
+    const estimatedToolTokens = measuredToolTokens || enabledToolCount * 350
     breakdown.toolDefinitions.tokens = estimatedToolTokens
     breakdown.toolDefinitions.toolCount = enabledToolCount
     breakdown.toolDefinitions.identified = false // Mark as estimated
@@ -356,7 +393,35 @@ export class ContextAnalyzer {
   /**
    * Estimate tool schema tokens from tool calls in the session
    */
-  private estimateToolSchemas(exported: ExportedSession): ToolSchemaEstimate[] {
+  private async estimateToolSchemas(
+    exported: ExportedSession,
+    tokenModel: TokenModel,
+    toolDefinitions: ToolListItem[]
+  ): Promise<ToolSchemaEstimate[]> {
+    if (toolDefinitions.length > 0) {
+      const estimates = await Promise.all(
+        toolDefinitions.map(async (definition) => {
+          const schema = this.toolSchema(definition)
+          const estimatedTokens =
+            this.toolTokenCache.get(definition) ??
+            (await this.tokenizerManager.countTokens(this.formatToolDefinition(definition), tokenModel))
+          this.setPrecomputedToolTokens(definition, estimatedTokens)
+
+          return {
+            name: definition.id,
+            enabled: true,
+            estimatedTokens,
+            argumentCount: this.countSchemaArguments(schema),
+            hasComplexArgs: this.hasComplexSchemaArguments(schema),
+            source: "opencode-api" as const,
+          }
+        })
+      )
+
+      estimates.sort((a, b) => b.estimatedTokens - a.estimatedTokens)
+      return estimates
+    }
+
     const enabledTools = this.extractEnabledTools(exported)
     const toolCallData = this.extractToolCallData(exported)
     const estimates: ToolSchemaEstimate[] = []
@@ -371,6 +436,7 @@ export class ContextAnalyzer {
         estimatedTokens: estimate.tokens,
         argumentCount: estimate.argCount,
         hasComplexArgs: estimate.hasComplex,
+        source: "transcript",
       })
     }
 
@@ -380,33 +446,161 @@ export class ContextAnalyzer {
     return estimates
   }
 
-  /**
-   * Extract enabled tools from user messages
-   */
-  private extractEnabledTools(exported: ExportedSession): Record<string, boolean> {
+  private async getToolDefinitions(providerID?: string, modelID?: string): Promise<ToolListItem[]> {
+    if (!this.client || !providerID || !modelID) {
+      return []
+    }
+
+    try {
+      const response = await fetchToolList(this.client, providerID, modelID, { directory: this.directory })
+      const tools = unwrapResponseData<ToolListItem[]>(response ?? [])
+      return Array.isArray(tools) ? tools.filter((tool) => typeof tool?.id === "string") : []
+    } catch (error) {
+      this.warnings?.add(
+        `Could not fetch tool definitions for ${providerID}/${modelID}. Tool schema sizes use transcript-based estimates: ${formatErrorMessage(error)}`,
+        `context-tool-list:${providerID}:${modelID}`
+      )
+      return []
+    }
+  }
+
+  private selectGeneratedSystemPrompts(prompts: string[]): string[] {
+    const strongPrompts = prompts.filter((prompt) => this.isStrongGeneratedSystemContext(prompt))
+    const hasBasePrompt = prompts.some((prompt) => this.isBaseGeneratedSystemPrompt(prompt))
+
+    if (strongPrompts.length === 0 || (strongPrompts.length === 1 && !hasBasePrompt)) {
+      return []
+    }
+
+    return prompts.filter(
+      (prompt) =>
+        this.isStrongGeneratedSystemContext(prompt) || this.isBaseGeneratedSystemPrompt(prompt) || this.isInstructionPrompt(prompt)
+    )
+  }
+
+  private isStrongGeneratedSystemContext(prompt: string): boolean {
+    const lower = prompt.toLowerCase()
+    return (
+      /<env>[\s\S]*?<\/env>/i.test(prompt) ||
+      /<available_skills>[\s\S]*?<\/available_skills>/i.test(prompt) ||
+      /<functions>[\s\S]*?<\/functions>/i.test(prompt) ||
+      (/^instructions from:\s*.+/im.test(prompt) &&
+        (lower.includes("agents.md") ||
+          lower.includes("claude.md") ||
+          lower.includes("context.md") ||
+          lower.includes("opencode"))) ||
+      lower.includes("available agent types and the tools they have access to") ||
+      lower.includes("skills provide specialized instructions and workflows")
+    )
+  }
+
+  private isBaseGeneratedSystemPrompt(prompt: string): boolean {
+    const lower = prompt.toLowerCase()
+    return (
+      lower.includes("you are opencode") ||
+      (prompt.length > 500 && lower.includes("assistant") && lower.includes("software engineering"))
+    )
+  }
+
+  private isInstructionPrompt(prompt: string): boolean {
+    return /^instructions from:\s*.+/im.test(prompt)
+  }
+
+  private toolSchema(tool: ToolListItem): unknown {
+    return tool.jsonSchema ?? tool.parameters
+  }
+
+  private formatToolDefinition(tool: ToolListItem): string {
+    const schema = this.toolSchema(tool)
+    return [
+      `<tool name="${tool.id}">`,
+      tool.description ? `<description>\n${tool.description}\n</description>` : undefined,
+      schema ? `<schema>\n${JSON.stringify(schema, null, 2)}\n</schema>` : undefined,
+      `</tool>`,
+    ]
+      .filter(Boolean)
+      .join("\n")
+  }
+
+  private countSchemaArguments(schema: unknown): number {
+    if (!schema || typeof schema !== "object") {
+      return 0
+    }
+
+    const properties = (schema as any).properties
+    return properties && typeof properties === "object" ? Object.keys(properties).length : 0
+  }
+
+  private hasComplexSchemaArguments(schema: unknown): boolean {
+    if (!schema || typeof schema !== "object") {
+      return false
+    }
+
+    const properties = (schema as any).properties
+    if (!properties || typeof properties !== "object") {
+      return false
+    }
+
+    return Object.values(properties).some((property) => {
+      if (!property || typeof property !== "object") return false
+      const type = (property as any).type
+      return type === "array" || type === "object" || !!(property as any).properties || !!(property as any).items
+    })
+  }
+
+  private sumPrecomputedToolTokens(tools: ToolListItem[]): number {
+    return tools.reduce((sum, tool) => sum + (this.toolTokenCache.get(tool) ?? 0), 0)
+  }
+
+  private setPrecomputedToolTokens(tool: ToolListItem, tokens: number): void {
+    this.toolTokenCache.set(tool, tokens)
+  }
+
+  private async precomputeToolDefinitionTokens(tools: ToolListItem[], tokenModel: TokenModel): Promise<void> {
+    await Promise.all(
+      tools.map(async (tool) => {
+        if (this.toolTokenCache.has(tool)) {
+          return
+        }
+
+        this.setPrecomputedToolTokens(tool, await this.tokenizerManager.countTokens(this.formatToolDefinition(tool), tokenModel))
+      })
+    )
+  }
+
+  private extractTranscriptTools(exported: ExportedSession): Record<string, boolean> {
     const tools: Record<string, boolean> = {}
 
     for (const message of exported.messages) {
-      // User messages may contain tools map in info
-      if (message.info.tools) {
-        for (const [name, enabled] of Object.entries(message.info.tools)) {
-          tools[name] = enabled
+      for (const part of message.parts) {
+        if (part.type === "tool" && part.tool) {
+          tools[part.tool] = true
         }
       }
     }
 
-    // Also collect from tool calls if tools map not available
     if (Object.keys(tools).length === 0) {
       for (const message of exported.messages) {
-        for (const part of message.parts) {
-          if (part.type === "tool" && part.tool) {
-            tools[part.tool] = true
-          }
+        if (!message.info.tools) continue
+        for (const [name, enabled] of Object.entries(message.info.tools)) {
+          if (enabled) tools[name] = true
         }
       }
     }
 
     return tools
+  }
+
+  private firstCacheWriteModel(exported: ExportedSession): { providerID?: string; modelID?: string } {
+    const call = collectTelemetryCalls(exported.messages).find((item) => item.cacheWriteTokens > 0)
+    return { providerID: call?.providerID, modelID: call?.modelID }
+  }
+
+  /**
+   * Extract enabled tools from user messages
+   */
+  private extractEnabledTools(exported: ExportedSession): Record<string, boolean> {
+    return this.extractTranscriptTools(exported)
   }
 
   /**

--- a/plugin/tokenscope-lib/formatter-insight-sections.ts
+++ b/plugin/tokenscope-lib/formatter-insight-sections.ts
@@ -80,10 +80,15 @@ export function formatToolEstimates(estimates: ToolSchemaEstimate[]): string[] {
   const lines: string[] = []
   const enabledEstimates = estimates.filter((e) => e.enabled)
   const totalTokens = enabledEstimates.reduce((sum, e) => sum + e.estimatedTokens, 0)
+  const usesOpenCodeMetadata = enabledEstimates.some((estimate) => estimate.source === "opencode-api")
 
   lines.push(``)
   lines.push(`═══════════════════════════════════════════════════════════════════════════`)
-  lines.push(`TOOL DEFINITION COSTS (Estimated from argument analysis)`)
+  lines.push(
+    usesOpenCodeMetadata
+      ? `TOOL DEFINITION COSTS (Tokenized from OpenCode tool metadata)`
+      : `TOOL DEFINITION COSTS (Estimated from argument analysis)`
+  )
   lines.push(`─────────────────────────────────────────────────────────────────────────`)
   lines.push(``)
   lines.push(`  ${"Tool".padEnd(TOOL_ESTIMATE_LABEL_WIDTH)} ${"Est. Tokens".padStart(12)}   Args   Complexity`)
@@ -102,8 +107,13 @@ export function formatToolEstimates(estimates: ToolSchemaEstimate[]): string[] {
     `  Total:${" ".repeat(TOOL_ESTIMATE_LABEL_WIDTH - 6)} ~${formatNumber(totalTokens).padStart(11)} tokens (${enabledEstimates.length} enabled tools)`
   )
   lines.push(``)
-  lines.push(`  Note: Estimates inferred from tool call arguments in this session.`)
-  lines.push(`        Actual schema tokens may vary +/-20%.`)
+  if (usesOpenCodeMetadata) {
+    lines.push(`  Note: Tokenized from the current OpenCode tool descriptions and JSON schemas.`)
+    lines.push(`        Provider-specific schema wrapping may still add small overhead.`)
+  } else {
+    lines.push(`  Note: Estimates inferred from tool call arguments in this session.`)
+    lines.push(`        Actual schema tokens may vary +/-20%.`)
+  }
 
   return lines
 }

--- a/plugin/tokenscope-lib/opencode.ts
+++ b/plugin/tokenscope-lib/opencode.ts
@@ -1,21 +1,77 @@
 // OpenCode SDK compatibility helpers
 
-export async function fetchSessionMessages(client: any, sessionID: string): Promise<any> {
-  try {
-    return await client.session.messages({ path: { id: sessionID } })
-  } catch (error) {
-    if (!client?.session?.messages) throw error
-    return await client.session.messages({ path: { sessionID } })
+type RequestAttempt = () => Promise<any>
+
+interface RoutingParams {
+  directory?: string
+  workspace?: string
+}
+
+function isFailedResponse(response: any): boolean {
+  return response === undefined || (!!response && typeof response === "object" && "error" in response && response.error !== undefined)
+}
+
+async function firstSuccessful(attempts: RequestAttempt[]): Promise<any> {
+  let lastError: unknown
+
+  for (const attempt of attempts) {
+    try {
+      const response = await attempt()
+      if (isFailedResponse(response)) {
+        lastError = response?.error ?? new Error("OpenCode API returned no data")
+        continue
+      }
+
+      return response
+    } catch (error) {
+      lastError = error
+    }
   }
+
+  throw lastError
+}
+
+export async function fetchSessionMessages(client: any, sessionID: string): Promise<any> {
+  const messages = client?.session?.messages
+  if (typeof messages !== "function") {
+    throw new Error("OpenCode session.messages API is unavailable")
+  }
+
+  return firstSuccessful([
+    () => messages.call(client.session, { path: { id: sessionID }, throwOnError: true }),
+    () => messages.call(client.session, { path: { sessionID }, throwOnError: true }),
+    () => messages.call(client.session, { sessionID }, { throwOnError: true }),
+  ])
 }
 
 export async function fetchSessionChildren(client: any, sessionID: string): Promise<any> {
-  try {
-    return await client.session.children({ path: { id: sessionID } })
-  } catch (error) {
-    if (!client?.session?.children) throw error
-    return await client.session.children({ path: { sessionID } })
+  const children = client?.session?.children
+  if (typeof children !== "function") {
+    throw new Error("OpenCode session.children API is unavailable")
   }
+
+  return firstSuccessful([
+    () => children.call(client.session, { path: { id: sessionID }, throwOnError: true }),
+    () => children.call(client.session, { path: { sessionID }, throwOnError: true }),
+    () => children.call(client.session, { sessionID }, { throwOnError: true }),
+  ])
+}
+
+export async function fetchToolList(
+  client: any,
+  providerID: string,
+  modelID: string,
+  routing: RoutingParams = {}
+): Promise<any> {
+  const list = client?.tool?.list
+  if (typeof list !== "function") {
+    throw new Error("OpenCode tool.list API is unavailable")
+  }
+
+  return firstSuccessful([
+    () => list.call(client.tool, { query: { ...routing, provider: providerID, model: modelID }, throwOnError: true }),
+    () => list.call(client.tool, { ...routing, provider: providerID, model: modelID }, { throwOnError: true }),
+  ])
 }
 
 export function unwrapResponseData<T>(response: any): T {

--- a/plugin/tokenscope-lib/session-workflow.ts
+++ b/plugin/tokenscope-lib/session-workflow.ts
@@ -87,7 +87,14 @@ export async function attachConfiguredAnalyses(input: {
   }
 
   const pricing = input.costCalculator.getPricing(input.pricingModelName)
-  const contextResult = await input.contextAnalyzer.analyze(input.sessionID, input.tokenModel, pricing, input.config)
+  const contextResult = await input.contextAnalyzer.analyze(
+    input.sessionID,
+    input.tokenModel,
+    pricing,
+    input.config,
+    input.providerID,
+    input.modelID
+  )
   applyContextAnalysis(input.analysis, contextResult)
 
   if (input.config.enableSkillAnalysis) {

--- a/plugin/tokenscope-lib/skill.ts
+++ b/plugin/tokenscope-lib/skill.ts
@@ -14,6 +14,7 @@ import type {
 import { isToolPart } from "./types.js"
 import { TokenizerManager } from "./tokenizer.js"
 import { WarningCollector, formatErrorMessage } from "./warnings.js"
+import { fetchToolList, unwrapResponseData } from "./opencode.js"
 
 interface ToolListItem {
   id: string
@@ -35,7 +36,7 @@ interface RemoteAgent {
 
 interface RemoteSkill {
   name: string
-  description: string
+  description?: string
   location?: string
 }
 
@@ -116,14 +117,8 @@ export class SkillAnalyzer {
    */
   private async listTools(providerID: string, modelID: string): Promise<ToolListItem[]> {
     try {
-      const response = await this.client.tool.list({
-        query: {
-          provider: providerID,
-          model: modelID,
-        },
-      })
-
-      const tools = (response as any)?.data ?? response ?? []
+      const response = await fetchToolList(this.client, providerID, modelID, { directory: this.directory })
+      const tools = unwrapResponseData<ToolListItem[]>(response ?? [])
       return Array.isArray(tools) ? (tools as ToolListItem[]) : []
     } catch (error) {
       this.warnings?.add(
@@ -150,7 +145,9 @@ export class SkillAnalyzer {
 
     try {
       if (availableSkills) {
-        const sortedSkills = [...availableSkills].sort((a, b) => a.name.localeCompare(b.name))
+        const sortedSkills = availableSkills
+          .filter((skill): skill is RemoteSkill & { description: string } => typeof skill.description === "string")
+          .sort((a, b) => a.name.localeCompare(b.name))
         const skillToolDescription = this.buildSkillToolDescription(sortedSkills)
         descriptionTokens = await this.tokenizerManager.countTokens(skillToolDescription, tokenModel)
 

--- a/plugin/tokenscope-lib/types.ts
+++ b/plugin/tokenscope-lib/types.ts
@@ -242,6 +242,7 @@ export interface ToolSchemaEstimate {
   estimatedTokens: number
   argumentCount: number
   hasComplexArgs: boolean
+  source?: "opencode-api" | "transcript"
 }
 
 // Skill analysis types

--- a/plugin/tokenscope.ts
+++ b/plugin/tokenscope.ts
@@ -54,7 +54,7 @@ export const TokenAnalyzerPlugin: Plugin = async ({ client, serverUrl, directory
           const tokenizerManager = new TokenizerManager(warnings)
           const analysisEngine = new TokenAnalysisEngine(tokenizerManager, contentCollector)
           const subagentAnalyzer = new SubagentAnalyzer(client, costCalculator, warnings)
-          const contextAnalyzer = new ContextAnalyzer(tokenizerManager, warnings)
+          const contextAnalyzer = new ContextAnalyzer(tokenizerManager, warnings, client, directory)
           const skillAnalyzer = new SkillAnalyzer(client, tokenizerManager, serverUrl, directory, warnings)
           const formatter = new OutputFormatter(costCalculator)
           formatter.setConfig(config)


### PR DESCRIPTION
Changed:
- Added OpenCode SDK compatibility helpers for both legacy and current parameter shapes:
  - `session.messages`
  - `session.children`
  - `tool.list`
- Updated tool-size analysis to use current OpenCode `/experimental/tool` metadata when available, tokenizing actual tool descriptions + JSON schemas instead of only inferring from call args.
- Updated context breakdown so user `info.system` overrides are not mistaken for generated OpenCode system context.
- Kept fallback transcript-based estimates when tool metadata is unavailable.
- Updated skill analysis to match current OpenCode behavior where skills without descriptions are omitted from available-skill prompt catalogs.
- Updated formatter notes to distinguish actual OpenCode tool metadata from inferred estimates.
- Added tests for SDK compatibility and context behavior.
