### PR TITLE
Fix Desktop context export fallback

### DIFF
--- a/plugin/test/context.test.ts
+++ b/plugin/test/context.test.ts
@@ -7,6 +7,7 @@ import { PassThrough } from "node:stream"
 
 import { ContextAnalyzer, createExportCommandRunner, defaultExportCommandRunner } from "../tokenscope-lib/context.js"
 import type { ExportedSession, TokenModel } from "../tokenscope-lib/types.js"
+import { WarningCollector } from "../tokenscope-lib/warnings.js"
 
 const tokenModel: TokenModel = { name: "test", spec: { kind: "approx" } }
 
@@ -181,6 +182,82 @@ test("context export runs from the session directory", async () => {
   )
 
   expect(calls).toEqual([{ sessionID: "ses_test", directory: "/tmp/project" }])
+})
+
+test("context export falls back to SDK session messages when opencode CLI is unavailable", async () => {
+  const warnings = new WarningCollector()
+  const calls: any[] = []
+  const client = {
+    session: {
+      async messages(input: any) {
+        calls.push(input)
+        return [
+          {
+            info: { id: "msg_assistant", role: "assistant" },
+            parts: [
+              {
+                type: "step-finish",
+                tokens: { input: 100, output: 10, cache: { read: 0, write: 2_000 }, reasoning: 0 },
+              },
+            ],
+          },
+        ]
+      },
+    },
+  }
+  const analyzer = new ContextAnalyzer(tokenizer, warnings, client, "C:\\project", async () => {
+    throw new Error("'opencode' is not recognized")
+  })
+
+  const result = await analyzer.analyze(
+    "ses_win",
+    tokenModel,
+    { input: 1, output: 3, cacheRead: 0, cacheWrite: 0 },
+    {
+      enableContextBreakdown: true,
+      enableToolSchemaEstimation: false,
+      enableCacheEfficiency: true,
+      enableSubagentAnalysis: false,
+      enableDetailedSubagentCostBreakdown: false,
+      enableSkillAnalysis: false,
+    }
+  )
+
+  expect(result.contextBreakdown?.totalCachedContext).toBe(2_000)
+  expect(result.cacheEfficiency?.cacheWriteTokens).toBe(2_000)
+  expect(warnings.list()).toEqual([])
+  expect(calls).toEqual([
+    {
+      path: { id: "ses_win" },
+      query: { directory: "C:\\project" },
+      throwOnError: true,
+    },
+  ])
+})
+
+test("context export reports both CLI and SDK failures when fallback cannot load messages", async () => {
+  const warnings = new WarningCollector()
+  const analyzer = new ContextAnalyzer(tokenizer, warnings, undefined, undefined, async () => {
+    throw new Error("'opencode' is not recognized")
+  })
+
+  const result = await analyzer.analyze(
+    "ses_win",
+    tokenModel,
+    { input: 1, output: 3, cacheRead: 0, cacheWrite: 0 },
+    {
+      enableContextBreakdown: true,
+      enableToolSchemaEstimation: false,
+      enableCacheEfficiency: false,
+      enableSubagentAnalysis: false,
+      enableDetailedSubagentCostBreakdown: false,
+      enableSkillAnalysis: false,
+    }
+  )
+
+  expect(result).toEqual({})
+  expect(warnings.list()[0]).toContain("'opencode' is not recognized")
+  expect(warnings.list()[0]).toContain("SDK fallback failed: OpenCode session.messages API is unavailable")
 })
 
 test("default export runner captures only opencode export stdout", async () => {

--- a/plugin/tokenscope-lib/context.ts
+++ b/plugin/tokenscope-lib/context.ts
@@ -19,7 +19,7 @@ import type {
 import { TokenizerManager } from "./tokenizer.js"
 import { collectTelemetryCalls, firstCacheWriteTokens, summarizeTelemetry } from "./telemetry.js"
 import { WarningCollector, formatErrorMessage } from "./warnings.js"
-import { fetchToolList, unwrapResponseData } from "./opencode.js"
+import { fetchSessionMessages, fetchToolList, unwrapResponseData } from "./opencode.js"
 
 interface ToolListItem {
   id: string
@@ -148,21 +148,45 @@ export class ContextAnalyzer {
    * Execute opencode export and parse the JSON output
    */
   private async runExport(sessionID: string): Promise<ExportedSession | null> {
+    let cliError: unknown
+
     try {
       const result = await this.exportCommandRunner(sessionID, this.directory)
+      return this.parseExportOutput(result)
+    } catch (error) {
+      cliError = error
+    }
 
-      if (!result.trim()) {
-        this.warnings?.add(`OpenCode export returned no data for session ${sessionID}. Context sections were skipped.`, `export-empty:${sessionID}`)
-        return null
-      }
-
-      return JSON.parse(result) as ExportedSession
+    try {
+      return await this.runSdkExport(sessionID)
     } catch (error) {
       this.warnings?.add(
-        `OpenCode export failed for session ${sessionID}. Context sections were skipped: ${formatErrorMessage(error)}`,
+        `OpenCode export failed for session ${sessionID}. Context sections were skipped: ${formatErrorMessage(cliError)}; SDK fallback failed: ${formatErrorMessage(error)}`,
         `export-failed:${sessionID}`
       )
       return null
+    }
+  }
+
+  private parseExportOutput(result: string): ExportedSession {
+    if (!result.trim()) {
+      throw new Error("OpenCode export returned no data")
+    }
+
+    return JSON.parse(result) as ExportedSession
+  }
+
+  private async runSdkExport(sessionID: string): Promise<ExportedSession> {
+    const response = await fetchSessionMessages(this.client, sessionID, { directory: this.directory })
+    const messages = unwrapResponseData<ExportedMessage[]>(response ?? [])
+
+    if (!Array.isArray(messages) || messages.length === 0) {
+      throw new Error("OpenCode session.messages returned no data")
+    }
+
+    return {
+      info: { id: sessionID, title: sessionID },
+      messages,
     }
   }
 


### PR DESCRIPTION
## Summary
- fall back to the OpenCode SDK session messages API when `opencode export` is unavailable
- preserve context/cache analysis on Windows Desktop installs without a CLI shim
- add regression coverage for SDK fallback and combined failure reporting

Closes #42

## Tests
- npm test